### PR TITLE
Better commandline parsing for `honcho run`

### DIFF
--- a/honcho/command.py
+++ b/honcho/command.py
@@ -147,8 +147,7 @@ class Honcho(object):
         "Run a command using your application's environment"
         self.set_env(self.read_env(options))
 
-        cmd = ' '.join(options.command)
-        p = Process(cmd, stdout=sys.stdout, stderr=sys.stderr)
+        p = Process(options.command, stdout=sys.stdout, stderr=sys.stderr)
         p.wait()
 
     @option('-p', '--port', type=int, default=5000, metavar='N')

--- a/honcho/process.py
+++ b/honcho/process.py
@@ -32,11 +32,13 @@ class Process(subprocess.Popen):
         defaults = {
             'stdout': subprocess.PIPE,
             'stderr': subprocess.STDOUT,
-            'shell': True,
             'bufsize': 1,
             'close_fds': ON_POSIX
         }
         defaults.update(kwargs)
+
+        if isinstance(cmd, basestring):
+            defaults.update(shell=True)
 
         super(Process, self).__init__(cmd, *args, **defaults)
 

--- a/test/integration/test_env.py
+++ b/test/integration/test_env.py
@@ -7,10 +7,3 @@ def test_env_start():
     assert_equal(ret, 0)
 
     assert_regexp_matches(out, r'animals\.1 \| (....)?I like giraffes')
-
-
-def test_env_run():
-    ret, out, err = get_honcho_output(['run', 'echo', '$TEST_ANIMAL'])
-
-    assert_equal(ret, 0)
-    assert_equal(out, 'giraffe\n')

--- a/test/integration/test_run.py
+++ b/test/integration/test_run.py
@@ -1,0 +1,22 @@
+from ..helpers import *
+
+
+def test_run_quoting():
+    ret, out, err = get_honcho_output(['run', 'python', '-c', 'print "hello world"'])
+
+    assert_equal(ret, 0)
+    assert_equal(out, 'hello world\n')
+
+
+def test_run_subshell():
+    ret, out, err = get_honcho_output(['run', 'echo', '$TEST_ANIMAL'])
+
+    assert_equal(ret, 0)
+    assert_equal(out, '$TEST_ANIMAL\n')
+
+
+def test_run_env():
+    ret, out, err = get_honcho_output(['run', 'sh', '-c', 'echo $TEST_ANIMAL'])
+
+    assert_equal(ret, 0)
+    assert_equal(out, 'giraffe\n')


### PR DESCRIPTION
Currently, `honcho run echo '$FOO'` will run "echo $FOO" in a subshell, which 
isn't consistent with other Unix tools that prefix arbitrary commandlines
(examples include `env(1)` and `xargs(1)`).

This commit changes the behaviour of `honcho run` to be more consistent with 
those tools, so that `honcho run echo '$FOO'` will actually run something
more like

```
os.execvp(['echo', '$FOO'])
```

This consistency comes at the cost of an internal inconsistency, namely that 
there is no longer a direct parallel between a Procfile containing

```
foo: echo $FOO
```

(which will execute in a subshell, and thus expand $FOO) and

```
honcho run echo '$FOO'
```

which will not expand $FOO. I'm not inclined to remove honcho's subshell 
execution when parsing Procfiles, due to the frequent necessity of
referencing environment variables (e.g. $PORT) in Procfiles, but I think the
command line interface should be consistent with `env(1)`, `xargs(1)` and
friends.
