### PR TITLE
Windows Process Termination

### DIFF
--- a/honcho/compat.py
+++ b/honcho/compat.py
@@ -1,7 +1,37 @@
 """
 Compatibility layer and utilities, mostly for proper Windows support
 """
+import ctypes
 import sys
+import time
+from datetime import datetime, timedelta
+
 
 # This works for both 32 and 64 bit Windows
 ON_WINDOWS = 'win32' in str(sys.platform).lower()
+
+
+def graceful_kill_windows(proc, timeout=2000):
+    """
+    gracefully kill a windows process, with a timeout
+    
+    send a ctrl-c event while disabling our own
+    ctrl event handler to prevent killing ourselves and then
+    re-enable our own ctrl handler and free the child console
+    after a small delay
+    """
+    def wait():
+        end = datetime.now() + timedelta(milliseconds=timeout)
+        while proc.poll() is None:
+            if datetime.now() >= end:
+                break
+            time.sleep(0.01)
+
+    if ctypes.windll.kernel32.AttachConsole(proc.pid):
+        ctypes.windll.kernel32.SetConsoleCtrlHandler(None, True)
+        ctypes.windll.kernel32.GenerateConsoleCtrlEvent(0, 0)
+        wait()
+        ctypes.windll.kernel32.FreeConsole()
+        ctypes.windll.kernel32.SetConsoleCtrlHandler(None, False)
+    else:
+        wait()


### PR DESCRIPTION
On windows, process termination is always forceful.  There is no chance for processes to do any cleanup.

This could be solved by using some ctypes kernel32 calls to send 'ctrl-c' to child processes, and then fall back on killing processes that still exist.

The code in this PR works both when running from the console, and when running honcho as a windows service.

If honcho is running in the console, ctrl-c events will be sent to all child processes already, so all that has to be done is give them time to do a graceful shutdown before killing them.

If honcho runs as a windows service, it first needs to connect to the child process consoles and raise the ctrl-c event, and then wait.

Unfortunately in windows when you kill a process its child processes are not also killed.  So if any process honcho launches is forcefully killed and also launched its own children, they will become orphaned.  The way around this is to use mozprocess (suggested by someone else previously) which keeps track of child processes and correctly kills them all.  I have not implemented this, but it should be fairly simple.
