### PR TITLE
Making the dependency on Jinja2 less restrictive.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 from honcho import __version__
 
-requirements = ['jinja2==2.6']
+requirements = ['jinja2>=2.6']
 
 if sys.version_info[:2] < (2, 7):
     requirements.append('argparse')


### PR DESCRIPTION
Given that there is now Jinja2 v2.7 that doesn't break backwards compatibility with v2.6, it seems safe to replace == with >=.
