### PR TITLE
Python 3 fix for printing error messages

### DIFF
--- a/honcho/command.py
+++ b/honcho/command.py
@@ -65,7 +65,6 @@ class CommandError(Exception):
 
 class Honcho(compat.with_metaclass(Commander, object)):
     "Manage Procfile-based applications"
-    __metaclass__ = Commander
 
     name = 'honcho'
     version = __version__
@@ -129,8 +128,9 @@ class Honcho(compat.with_metaclass(Commander, object)):
         try:
             options.func(self, options)
         except CommandError as e:
-            if e.message:
-                log.error(e.message)
+            message = str(e) if compat.IS_PY3 else e.message
+            if message:
+                log.error(message)
             sys.exit(1)
 
     @arg('task', help='Task to show help for', nargs='?')


### PR DESCRIPTION
As there is no message attribute for Python 3 Exception instances, I cast CommandError to str instead. Yes, we can do join args here, but casting to str is much easier.
