### PR TITLE
Adds a quiet option to `start`

### DIFF
--- a/honcho/command.py
+++ b/honcho/command.py
@@ -163,6 +163,7 @@ class Honcho(compat.with_metaclass(Commander, object)):
 
     @option('-p', '--port', type=int, default=5000, metavar='N')
     @option('-c', '--concurrency', help='The number of each process type to run.', type=str, metavar='process=num,process=num')
+    @option('-q', '--quiet', help='Any processes that you want to quiet ouput of.', type=str, metavar='process1,process2,process3')
     @arg('process', nargs='?', help='Name of process to start. All processes will be run if omitted.')
     def start(self, options):
         "Start the application (or a specific PROCESS)"
@@ -171,6 +172,8 @@ class Honcho(compat.with_metaclass(Commander, object)):
 
         port = int(os.environ.get('PORT', options.port))
         concurrency = self.parse_concurrency(options.concurrency)
+        quiet = self.parse_quiet(options.quiet)
+
 
         if options.process is not None:
             try:
@@ -184,7 +187,7 @@ class Honcho(compat.with_metaclass(Commander, object)):
             for i in compat.xrange(concurrency[name]):
                 n = '{name}.{num}'.format(name=name, num=i + 1)
                 os.environ['PORT'] = str(port + i)
-                process_manager.add_process(n, cmd)
+                process_manager.add_process(n, cmd, quiet=(name in quiet))
             port += 100
 
         sys.exit(process_manager.loop())
@@ -285,6 +288,14 @@ class Honcho(compat.with_metaclass(Commander, object)):
             key, concurrency = item.split('=', 1)
             result[key] = int(concurrency)
         return result
+
+    def parse_quiet(self, desc):
+        result = []
+        if desc is None:
+            return result
+        result = desc.split(',')
+        return result
+
 
 
 def main():

--- a/test/fixtures/Procfile.quiet
+++ b/test/fixtures/Procfile.quiet
@@ -1,0 +1,4 @@
+foo: python output.py
+bar: python output.py
+baz: python output.py
+

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -11,12 +11,21 @@ if not 'assert_regexp_matches' in globals():
 
     def assert_regexp_matches(text, expected_regexp, msg=None):
         """Fail the test unless the text matches the regular expression."""
-        if isinstance(expected_regexp, basestring):
+        if isinstance(expected_regexp, str):
             expected_regexp = re.compile(expected_regexp)
         if not expected_regexp.search(text):
             msg = msg or "Regexp didn't match"
             msg = '%s: %r not found in %r' % (msg, expected_regexp.pattern, text)
             raise AssertionError(msg)
+
+def assert_regexp_fails(text, failed_regexp, msg=None):
+    """Fail the test if the text matches the regular expression."""
+    if isinstance(failed_regexp, str):
+        failed_regexp = re.compile(failed_regexp)
+    if failed_regexp.search(text):
+        msg = msg or "Regexp matched"
+        msg = '%s: %r found in %r' % (msg, failed_regexp.pattern, text)
+        raise AssertionError(msg)
 
 
 def get_honcho_output(args):

--- a/test/integration/test_quiet.py
+++ b/test/integration/test_quiet.py
@@ -1,0 +1,38 @@
+from ..helpers import *
+
+
+def test_single_quiet():
+    ret, out, err = get_honcho_output(['-f', 'Procfile.quiet', 'start', '-qbaz'])
+
+    assert_equal(ret, 0)
+
+    assert_regexp_matches(out, r'foo\.1 *\| (....)?some normal output')
+    assert_regexp_matches(out, r'foo\.1 *\| (....)?and then write to stderr')
+    assert_regexp_matches(out, r'bar\.1 *\| (....)?some normal output')
+    assert_regexp_matches(out, r'bar\.1 *\| (....)?and then write to stderr')
+    assert_regexp_fails(out, r'baz\.1 \(quiet\) *\| (....)?some normal output')
+    assert_regexp_fails(out, r'baz\.1 \(quiet\) *\| (....)?and then write to stderr')
+
+    assert_regexp_matches(out, r'baz\.1 \(quiet\) *\| (....)?started with pid \d+\n')
+    assert_regexp_matches(out, r'baz\.1 \(quiet\) *\| (....)?process terminated\n')
+
+    assert_equal(err, '')
+
+def test_multi_quiet():
+    ret, out, err = get_honcho_output(['-f', 'Procfile.quiet', 'start', '-qbaz,bar'])
+
+    assert_equal(ret, 0)
+
+    assert_regexp_matches(out, r'foo\.1 *\| (....)?some normal output')
+    assert_regexp_matches(out, r'foo\.1 *\| (....)?and then write to stderr')
+    assert_regexp_fails(out, r'bar\.1 \(quiet\) *\| (....)?some normal output')
+    assert_regexp_fails(out, r'bar\.1 \(quiet\) *\| (....)?and then write to stderr')
+    assert_regexp_fails(out, r'baz\.1 \(quiet\) *\| (....)?some normal output')
+    assert_regexp_fails(out, r'baz\.1  \(quiet\)*\| (....)?and then write to stderr')
+
+    assert_regexp_matches(out, r'bar\.1 \(quiet\) *\| (....)?started with pid \d+\n')
+    assert_regexp_matches(out, r'bar\.1 \(quiet\) *\| (....)?process terminated\n')
+    assert_regexp_matches(out, r'baz\.1 \(quiet\) *\| (....)?started with pid \d+\n')
+    assert_regexp_matches(out, r'baz\.1 \(quiet\) *\| (....)?process terminated\n')
+
+    assert_equal(err, '')

--- a/test/unit/test_process.py
+++ b/test/unit/test_process.py
@@ -10,6 +10,6 @@ class TestProcessManager(object):
         pm.add_process('foo', 'ruby server.rb')
         pm.add_process('bar', 'python worker.py')
 
-        expected = [call('ruby server.rb', name='foo'), call('python worker.py', name='bar')]
+        expected = [call('ruby server.rb', name='foo', quiet=False), call('python worker.py', name='bar', quiet=False)]
 
         assert_equal(process_mock.mock_calls, expected)


### PR DESCRIPTION
I use honcho to manage my application and I got sick of redid overwhelming the logs:

![screen shot 2013-07-31 at 8 32 52 pm](https://f.cloud.github.com/assets/1097953/891471/19f1ad3a-fa5b-11e2-853c-3f40a6e67a74.png)

As such, I figured I would add a quiet option, which could suppress output from particularly noisy processes. With the quiet option enable on redis, my log is much more manageable:

![screen shot 2013-07-31 at 8 35 03 pm](https://f.cloud.github.com/assets/1097953/891480/80256272-fa5b-11e2-9706-a5056d4353f5.png)

Usage is really easy:

```
-q process1,process2
--quiet process1, process2 
```

I've added tests to ensure functionality works.

Would love to hear people's thoughts!
