### PR TITLE
Use Jinja2 2.7.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 from honcho import __version__
 
-requirements = ['jinja2==2.7']
+requirements = ['jinja2==2.7.1']
 
 if sys.version_info[:2] < (2, 7):
     requirements.append('argparse')


### PR DESCRIPTION
Jinja2 2.7.1 has released on August 7th, 2013.

It was a just bugfix release and there's no API change. ([changelog](https://github.com/mitsuhiko/jinja2/commit/7253ca41ed78e82356a2d2a892b64ff25b81ca1b))
