### PR TITLE
use quotes for values of environment variables in exported scripts

### DIFF
--- a/honcho/data/export/upstart/process.conf
+++ b/honcho/data/export/upstart/process.conf
@@ -2,4 +2,4 @@ start on starting {{app}}-{{name}}
 stop on stopping {{app}}-{{name}}
 respawn
 
-exec su - {{user}} -s {{shell}} -c 'cd {{app_root}}; export PORT={{port}};{% for var, val in environment.iteritems() %} export {{var|upper}}={{val}};{% endfor %} {{ command }} >> {{ log }}/{{ name }}-{{ num }}.log 2>&1'
+exec su - {{user}} -s {{shell}} -c 'cd {{app_root}}; export PORT={{port}};{% for var, val in environment.iteritems() %} export {{var|upper}}="{{val}}";{% endfor %} {{ command }} >> {{ log }}/{{ name }}-{{ num }}.log 2>&1'


### PR DESCRIPTION
This is needed for variables that have spaces in their values.
