### PR TITLE
use a shell for supervisor

### DIFF
--- a/honcho/data/export/supervisord/supervisord.conf
+++ b/honcho/data/export/supervisord/supervisord.conf
@@ -1,6 +1,6 @@
 {% for name,command,full_name,num,env in commands %}
 [program:{{ full_name }}]
-command={{ command }}
+command=/bin/sh -c '{{ command }}'
 autostart=true
 autorestart=true
 stopsignal=QUIT


### PR DESCRIPTION
this expands env variables correctly.

Fixes #49
