### PR TITLE
Fix crash in start when all processes are quiet

### DIFF
--- a/honcho/process.py
+++ b/honcho/process.py
@@ -185,9 +185,7 @@ class ProcessManager(object):
             t.start()
 
     def _init_printers(self):
-        width = max(len(p.name) for p in filter(lambda x: not x.quiet, self.processes))
-        width = max(width, len(self.system_printer.name))
-
+        width = self._printer_width()
         self.system_printer.width = width
 
         for proc in self.processes:
@@ -195,6 +193,11 @@ class ProcessManager(object):
                                    name=proc.name,
                                    colour=next(self.colours),
                                    width=width)
+
+    def _printer_width(self):
+        name_lengths = [len(p.name) for p in self.processes if not p.quiet]
+        name_lengths.append(len(self.system_printer.name))
+        return max(name_lengths)
 
     def _print_line(self, proc, line):
         if isinstance(line, UnicodeDecodeError):

--- a/test/integration/test_start.py
+++ b/test/integration/test_start.py
@@ -110,3 +110,25 @@ def test_start_quiet_multi():
     assert_regexp_matches(out, r'baz\.1 \(quiet\) *\| (....)?process terminated\n')
 
     assert_equal(err, '')
+
+
+def test_start_quiet_all():
+    ret, out, err = get_honcho_output(['-f', 'Procfile.default', 'start', '-qfoo,baz,bar'])
+
+    assert_equal(ret, 0)
+
+    assert_regexp_fails(out, r'foo\.1 \(quiet\) *\| (....)?normal output')
+    assert_regexp_fails(out, r'foo\.1 \(quiet\) *\| (....)?error output')
+    assert_regexp_fails(out, r'bar\.1 \(quiet\) *\| (....)?normal output')
+    assert_regexp_fails(out, r'bar\.1 \(quiet\) *\| (....)?error output')
+    assert_regexp_fails(out, r'baz\.1 \(quiet\) *\| (....)?normal output')
+    assert_regexp_fails(out, r'baz\.1  \(quiet\)*\| (....)?error output')
+
+    assert_regexp_matches(out, r'foo\.1 \(quiet\) *\| (....)?started with pid \d+\n')
+    assert_regexp_matches(out, r'foo\.1 \(quiet\) *\| (....)?process terminated\n')
+    assert_regexp_matches(out, r'bar\.1 \(quiet\) *\| (....)?started with pid \d+\n')
+    assert_regexp_matches(out, r'bar\.1 \(quiet\) *\| (....)?process terminated\n')
+    assert_regexp_matches(out, r'baz\.1 \(quiet\) *\| (....)?started with pid \d+\n')
+    assert_regexp_matches(out, r'baz\.1 \(quiet\) *\| (....)?process terminated\n')
+
+    assert_equal(err, '')


### PR DESCRIPTION
Specifying all processes in a Procfile as --quiet, caused `max` to be
called with no arguments, which crashes.
