### PR TITLE
Ignore Ctrl-C in `honcho run`

### DIFF
--- a/honcho/command.py
+++ b/honcho/command.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import os
 import re
+import signal
 import sys
 from collections import defaultdict
 try:
@@ -158,6 +159,10 @@ class Honcho(compat.with_metaclass(Commander, object)):
             cmd = ' '.join(shellquote(arg) for arg in options.command)
 
         p = Process(cmd, stdout=sys.stdout, stderr=sys.stderr)
+
+        # Ignore SIGINT; let the child process handle that
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+
         p.wait()
         sys.exit(p.returncode)
 


### PR DESCRIPTION
When running ad hoc commands under Honcho with `honcho run`, Honcho
currently does not give the spawned process an opportunity to handle
Ctrl-C. In addition to an ugly `KeyboardInterrupt` traceback, this
can cause the terminal to be left in an inconsistent state.

For instance, when running a command that switches the terminal to
raw mode (`honcho run python`), the terminal is left in raw mode after
honcho exits, requiring an `stty sane` to restore it.

This patch causes the `honcho run` command to ignore Ctrl-C (SIGINT)
while waiting for the spawned command process to exit, allowing the
command to handle it however it sees fit.
