### PR TITLE
fix UnicodeEncodeError when environment variables PYTHONUNBUFFERED=true

### DIFF
--- a/honcho/compat.py
+++ b/honcho/compat.py
@@ -13,8 +13,8 @@ try:
     sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout.buffer, 'strict')
     sys.stderr = codecs.getwriter(locale.getpreferredencoding())(sys.stderr.buffer, 'strict')
 except AttributeError:
-    sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout, 'strict')
-    sys.stderr = codecs.getwriter(locale.getpreferredencoding())(sys.stderr, 'strict')
+    sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout)
+    sys.stderr = codecs.getwriter(locale.getpreferredencoding())(sys.stderr)
 
 # This works for both 32 and 64 bit Windows
 ON_WINDOWS = 'win32' in str(sys.platform).lower()


### PR DESCRIPTION
In Non-English environment
PYTHONUNBUFFERED=true honcho start web

Traceback (most recent call last):
  File "app_main.py", line 75, in run_toplevel
  File ".virtualenv/bin/honcho", line 9, in <module>
    load_entry_point('honcho==0.5.0', 'console_scripts', 'honcho')()
  File "/Users/ratazzi/workspace/stats/.virtualenv/site-packages/honcho/command.py", line 315, in main
    app.parse()
  File "/Users/ratazzi/workspace/stats/.virtualenv/site-packages/honcho/command.py", line 129, in parse
    options.func(self, options)
  File "/Users/ratazzi/workspace/stats/.virtualenv/site-packages/honcho/command.py", line 197, in start
    sys.exit(process_manager.loop())
  File "/Users/ratazzi/workspace/stats/.virtualenv/site-packages/honcho/process.py", line 118, in loop
    print(line, end='', file=proc.printer)
  File "/Users/ratazzi/workspace/stats/.virtualenv/site-packages/honcho/printer.py", line 22, in write
    self.output.write(_new_args, *_kwargs)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 27-29: ordinal not in range(128)
