### PR TITLE
Evaluate .env file with shlex instead of regex.

### DIFF
--- a/honcho/environ.py
+++ b/honcho/environ.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from collections import namedtuple
 import datetime
 import errno
+import shlex
 import os
 import re
 
@@ -67,15 +68,11 @@ def parse(content):
         m1 = re.match(r'\A([A-Za-z_0-9]+)=(.*)\Z', line)
         if m1:
             key, val = m1.group(1), m1.group(2)
-
-            m2 = re.match(r"\A'(.*)'\Z", val)
-            if m2:
-                val = m2.group(1)
-
-            m3 = re.match(r'\A"(.*)"\Z', val)
-            if m3:
-                val = re.sub(r'\\(.)', r'\1', m3.group(1))
-
+            parts = shlex.split(val, posix=True)
+            if len(parts) == 1:
+                val = parts[0]
+            else:
+                val = ' '.join("'%s'" % p for p in parts)
             values[key] = val
     return values
 


### PR DESCRIPTION
Or any string with quotes will be broken.

e.g. `FOO='"foo"'`
