### PR TITLE
Add "version" command

### DIFF
--- a/honcho/command.py
+++ b/honcho/command.py
@@ -228,12 +228,25 @@ parser_start.add_argument(
     help='process(es) to start (default: all processes will be run)')
 
 
+def command_version(args):
+    print('{prog} {version}'.format(
+        prog=parser.prog,
+        version=__version__))
+
+
+parser_version = subparsers.add_parser(
+    'version',
+    help="display honcho version",
+    **_parser_defaults)
+
+
 COMMANDS = {
     'check': command_check,
     'export': command_export,
     'help': command_help,
     'run': command_run,
     'start': command_start,
+    'version': command_version,
 }
 
 


### PR DESCRIPTION
for parity with foreman.

I don't know if matching foreman is a goal, but I noticed that honcho supports every command that foreman does, except for this one, so I figured it didn't hurt. Plus I needed a warm-up task before I get to the real change I'm desiring to add to honcho (ability to specify a custom template for supervisord export). :-)

```
[marca@marca-mac2 honcho]$ foreman help
Commands:
  foreman check                   # Validate your application's Procfile
  foreman export FORMAT LOCATION  # Export the application to another process management format
  foreman help [COMMAND]          # Describe available commands or one specific command
  foreman run COMMAND [ARGS...]   # Run a command using your application's environment
  foreman start [PROCESS]         # Start the application (or a specific PROCESS)
  foreman version                 # Display Foreman gem version

Options:
  -f, [--procfile=PROCFILE]  # Default: Procfile
  -d, [--root=ROOT]          # Default: Procfile directory

[marca@marca-mac2 honcho]$ honcho help
usage: honcho [-h] [-e ENV] [-d APP_ROOT] [-f PROCFILE] [-v]
              {check,export,help,run,start,version} ...

optional arguments:
  -h, --help            show this help message and exit
  -e ENV, --env ENV     environment file[,file] (default: .env)
  -d APP_ROOT, --app-root APP_ROOT
                        procfile directory (default: .)
  -f PROCFILE, --procfile PROCFILE
                        procfile path (default: Procfile)
  -v, --version         show program's version number and exit

tasks:
  {check,export,help,run,start,version}
    check               validate a Procfile
    export              export a Procfile to another format
    help                describe available tasks or one specific task
    run                 run a command using your application's environment
    start               start the application (or a specific PROCESS)
    version             display honcho version
[marca@marca-mac2 honcho]$ honcho version
honcho 0.5.0
```
