### PR TITLE
honcho export --help: List format choices

### DIFF
--- a/honcho/command.py
+++ b/honcho/command.py
@@ -129,7 +129,7 @@ parser_export.add_argument(
     type=str, metavar="LOCATION")
 parser_export.add_argument(
     'format',
-    help="format in which to export",
+    help="format to export to; one of %(choices)s",
     choices=list(export_choices),
     type=str, metavar="FORMAT")
 


### PR DESCRIPTION
Before:

```
$ honcho export --help
...
  FORMAT                format in which to export
```

After:

```
$ honcho export --help
  FORMAT                format to export to; one of upstart, supervisord
```
