### PR TITLE
export: Reverse order of FORMAT and LOCATION args

### DIFF
--- a/honcho/command.py
+++ b/honcho/command.py
@@ -124,14 +124,14 @@ parser_export.add_argument(
     help="the shell that should run the application",
     default='/bin/sh', type=str)
 parser_export.add_argument(
-    'location',
-    help="folder to export to",
-    type=str, metavar="LOCATION")
-parser_export.add_argument(
     'format',
     help="format in which to export",
     choices=list(export_choices),
     type=str, metavar="FORMAT")
+parser_export.add_argument(
+    'location',
+    help="folder to export to",
+    type=str, metavar="LOCATION")
 
 
 def command_help(args):


### PR DESCRIPTION
to match [foreman](http://ddollar.github.io/foreman/)

```
$ foreman help export | head -n 2
Usage:
  foreman export FORMAT LOCATION
```

and also [Honcho's own docs](https://honcho.readthedocs.org/en/latest/export.html)

```
$ honcho export OPTIONS FORMAT LOCATION
```
### Before:

```
$ honcho help export | head -n 4
usage: honcho export [-h] [-e ENV] [-d APP_ROOT] [-f PROCFILE] [-v] [-a APP]
                     [-l DIR] [-p N] [-c process=num,process=num] [-u USER]
                     [-s SHELL]
                     LOCATION FORMAT
```
### After:

```
$ honcho help export | head -n 4
usage: honcho export [-h] [-e ENV] [-d APP_ROOT] [-f PROCFILE] [-v] [-a APP]
                     [-l DIR] [-p N] [-c process=num,process=num] [-u USER]
                     [-s SHELL]
                     FORMAT LOCATION
```

Fixes: GH-91
