### PR TITLE
Add --pdb option; invokes pdb on exception

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -118,4 +118,37 @@ within tox. E.g. if youd'd like to use nose ``-x`` flag (stop after first error)
 
     tox -e pypy -- -x
 
+If while running ``honcho``, you get an error and it's not very helpful -- e.g.::
 
+    $ honcho export supervisord .
+    [Errno 13] Permission denied: '/var/log/export_test'
+    2014-11-26 11:01:26 [23742] [ERROR] Can not create /var/log/export_test
+
+you can try using the ``--pdb`` option to try to diagnose it::
+
+    $ honcho export supervisord . --pdb
+    [Errno 13] Permission denied: '/var/log/export_test'
+    Traceback (most recent call last):
+      File "/Users/marca/dev/git-repos/honcho/honcho/command.py", line 253, in main
+        COMMANDS[args.command](args)
+      File "/Users/marca/dev/git-repos/honcho/honcho/command.py", line 106, in command_export
+        export.export()
+      File "/Users/marca/dev/git-repos/honcho/honcho/export/base.py", line 86, in export
+        self._mkdir(self.options.log)
+      File "/Users/marca/dev/git-repos/honcho/honcho/export/base.py", line 47, in _mkdir
+        .format(directory))
+    CommandError: Can not create /var/log/export_test
+    > /Users/marca/dev/git-repos/honcho/honcho/export/base.py(47)_mkdir()
+    -> .format(directory))
+    (Pdb) directory
+    '/var/log/export_test'
+    (Pdb) bt
+      /Users/marca/dev/git-repos/honcho/honcho/command.py(253)main()
+    -> COMMANDS[args.command](args)
+      /Users/marca/dev/git-repos/honcho/honcho/command.py(106)command_export()
+    -> export.export()
+      /Users/marca/dev/git-repos/honcho/honcho/export/base.py(86)export()
+    -> self._mkdir(self.options.log)
+    > /Users/marca/dev/git-repos/honcho/honcho/export/base.py(47)_mkdir()
+    -> .format(directory))
+    (Pdb)

--- a/honcho/command.py
+++ b/honcho/command.py
@@ -2,8 +2,10 @@ import argparse
 import codecs
 import logging
 import os
+import pdb
 import sys
 import signal
+import traceback
 from collections import defaultdict
 from pkg_resources import iter_entry_points
 
@@ -51,6 +53,10 @@ _parent_parser.add_argument(
 _parent_parser.add_argument(
     '-v', '--version',
     action='version', version='%(prog)s ' + __version__)
+_parent_parser.add_argument(
+    '--pdb',
+    action='store_true',
+    help='Activate pdb on exception; for debugging')
 
 _parser_defaults = {
     'parents': [_parent_parser],
@@ -259,8 +265,13 @@ def main(argv=None):
     try:
         COMMANDS[args.command](args)
     except CommandError as e:
-        log.error(str(e))
-        sys.exit(1)
+        if args.pdb:
+            type, value, tb = sys.exc_info()
+            traceback.print_exc()
+            pdb.post_mortem(tb)
+        else:
+            log.error(str(e))
+            sys.exit(1)
 
 
 def _procfile_path(app_root, procfile):


### PR DESCRIPTION
Useful for debugging. Looks like this:

```
$ honcho export . supervisord  --pdb
[Errno 13] Permission denied: '/var/log/export_test'
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/honcho/honcho/command.py", line 253, in main
    COMMANDS[args.command](args)
  File "/Users/marca/dev/git-repos/honcho/honcho/command.py", line 106, in command_export
    export.export()
  File "/Users/marca/dev/git-repos/honcho/honcho/export/base.py", line 86, in export
    self._mkdir(self.options.log)
  File "/Users/marca/dev/git-repos/honcho/honcho/export/base.py", line 47, in _mkdir
    .format(directory))
CommandError: Can not create /var/log/export_test
> /Users/marca/dev/git-repos/honcho/honcho/export/base.py(47)_mkdir()
-> .format(directory))
(Pdb) directory
'/var/log/export_test'
(Pdb) bt
  /Users/marca/dev/git-repos/honcho/honcho/command.py(253)main()
-> COMMANDS[args.command](args)
  /Users/marca/dev/git-repos/honcho/honcho/command.py(106)command_export()
-> export.export()
  /Users/marca/dev/git-repos/honcho/honcho/export/base.py(86)export()
-> self._mkdir(self.options.log)
> /Users/marca/dev/git-repos/honcho/honcho/export/base.py(47)_mkdir()
-> .format(directory))
(Pdb)
```

Or if you're using [pdbpp](https://pypi.python.org/pypi/pdbpp/) (highly recommended), you get this awesomeness:

![screen shot 2014-11-26 at 11 07 35 am](https://cloud.githubusercontent.com/assets/305268/5207200/ff63d3ac-755c-11e4-90a3-e765033b20f5.png)
