### PR TITLE
export: Don't require log directory to exist

### DIFF
--- a/honcho/export/base.py
+++ b/honcho/export/base.py
@@ -83,8 +83,6 @@ class BaseExport(object):
 
     def export(self):
         self._mkdir(self.options.location)
-        self._mkdir(self.options.log)
-        self._chown(self.options.log)
 
         files = self.render(self.procfile,
                             self.options,


### PR DESCRIPTION
`-l`/`--log` is the directory to place process logs in, so you should only need this directory at runtime. The log directory shouldn't be required to exist at export-time, because you might just export the `Procfile` to a supervisord config and then use that exported config to run processes on another box altogether.

```
[marca@marca-mac2 export_test]$ ls -l
total 8
-rw-r--r--+ 1 marca  staff  23 Nov 26 08:15 Procfile

[marca@marca-mac2 export_test]$ honcho export . supervisord

[marca@marca-mac2 export_test]$ ls -l
total 16
-rw-r--r--+ 1 marca  staff   23 Nov 26 08:15 Procfile
-rw-r--r--+ 1 marca  staff  354 Nov 26 11:15 export_test.conf

[marca@marca-mac2 export_test]$ cat export_test.conf | grep log
stdout_logfile=/path/to/log/dir/ansvc-0.log
stderr_logfile=/path/to/log/dir/ansvc-0.error.log
```

Fixes: GH-90
