### PR TITLE
supervisord template: \n at end; not at beginning

### DIFF
--- a/honcho/data/export/supervisord/supervisord.conf
+++ b/honcho/data/export/supervisord/supervisord.conf
@@ -1,4 +1,4 @@
-{% for name,command,full_name,num,env in processes %}
+{% for name,command,full_name,num,env in processes -%}
 [program:{{ full_name }}]
 command={{ shell }} -c '{{ command }}'
 autostart=true
@@ -8,7 +8,8 @@ stdout_logfile={{ log }}/{{ name }}-{{ num }}.log
 stderr_logfile={{ log }}/{{ name }}-{{ num }}.error.log
 user={{ user }}
 directory={{ app_root }}
-environment={% for key,value in env %}{{ key }}={{ value }}{% if not loop.last %},{% endif %}{% endfor %}{% endfor %}
-
+environment={% for key,value in env %}{{ key }}={{ value }}{% if not loop.last %},{% endif %}{% endfor %}
+{% endfor %}
 [group:{{ app }}]
 programs={% for name,command,full_name,num,env in processes %}{{ full_name }}{% if not loop.last %},{% endif %}{% endfor %}
+


### PR DESCRIPTION
It's a UNIX convention that text files should always end with a newline. One of the best reasons for this is that it makes possible to do `cat file1.txt file2.txt > combined.txt` and have the result make sense. For more info:

http://stackoverflow.com/questions/729692/why-should-files-end-with-a-newline

I also modified the template slightly so it doesn't generate a blank line at the beginning of the file. I don't think it does any harm, but I think it looks slightly better without it.
