### PR TITLE
Add logging to test_supervisord_concurrency

### DIFF
--- a/honcho/test/unit/test_export_supervisord.py
+++ b/honcho/test/unit/test_export_supervisord.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from collections import defaultdict, namedtuple
 from ..helpers import TestCase
@@ -15,6 +16,8 @@ DEFAULT_OPTIONS = Options(app="app", app_root="/path/to/app", format="supervisor
 DEFAULT_ENV = {}
 
 DEFAULT_CONCURRENCY = defaultdict(lambda: 1)
+
+logger = logging.getLogger(__name__)
 
 
 def get_render(procfile, options, environment, concurrency):
@@ -48,6 +51,7 @@ class TestExportSupervisord(TestCase):
 
         self.assertEqual(1, len(render))
         (fname, contents), = render
+        logger.debug('contents =\n%s', contents)
 
         parser = compat.ConfigParser()
         parser.readfp(compat.StringIO(contents))


### PR DESCRIPTION
This turned out to be very useful when debugging test failures I was getting while working on PR #96.

`nosetests` has built-in support for capturing log output and printing it ([`pytest`](http://pytest.org/) can also do this if you install [pytest-capturelog](https://pypi.python.org/pypi/pytest-capturelog)).

Note how I can see in the output below that I had a bug where it wasn't putting a newline in between `[program]` sections:

```
environment=PORT="5000"[program:app-foo-1]
```

```
$ nosetests -v honcho.test.unit.test_export_supervisord:TestExportSupervisord.test_supervisord_concurrency
test_supervisord_concurrency (honcho.test.unit.test_export_supervisord.TestExportSupervisord) ... FAIL

======================================================================
FAIL: test_supervisord_concurrency (honcho.test.unit.test_export_supervisord.TestExportSupervisord)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/honcho/honcho/test/unit/test_export_supervisord.py", line 64, in test_supervisord_concurrency
    parser.get(section, "environment"))
AssertionError: 'PORT="5000"' != u'PORT="5003"'
-------------------- >> begin captured logging << --------------------
honcho.test.unit.test_export_supervisord: DEBUG: contents =
[program:app-foo-0]
command=/usr/local/shell -c 'python simple.py'
autostart=true
autorestart=true
stopsignal=QUIT
stdout_logfile=/path/to/log/foo-0.log
stderr_logfile=/path/to/log/foo-0.error.log
user=marca
directory=/path/to/app
environment=PORT="5000"[program:app-foo-1]
command=/usr/local/shell -c 'python simple.py'
autostart=true
autorestart=true
stopsignal=QUIT
stdout_logfile=/path/to/log/foo-1.log
stderr_logfile=/path/to/log/foo-1.error.log
user=marca
directory=/path/to/app
environment=PORT="5001"[program:app-foo-2]
command=/usr/local/shell -c 'python simple.py'
autostart=true
autorestart=true
stopsignal=QUIT
stdout_logfile=/path/to/log/foo-2.log
stderr_logfile=/path/to/log/foo-2.error.log
user=marca
directory=/path/to/app
environment=PORT="5002"[program:app-foo-3]
command=/usr/local/shell -c 'python simple.py'
autostart=true
autorestart=true
stopsignal=QUIT
stdout_logfile=/path/to/log/foo-3.log
stderr_logfile=/path/to/log/foo-3.error.log
user=marca
directory=/path/to/app
environment=PORT="5003"
[group:app]
programs=app-foo-0,app-foo-1,app-foo-2,app-foo-3

--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 1 test in 0.013s

FAILED (failures=1)
```
