### PR TITLE
export: Add help string for -p/--port option

### DIFF
--- a/honcho/command.py
+++ b/honcho/command.py
@@ -110,7 +110,10 @@ parser_export.add_argument(
     '-l', '--log',
     help="directory to place process logs in",
     default="/var/log/APP", type=str, metavar='DIR')
-parser_export.add_argument('-p', '--port', default=5000, type=int, metavar='N')
+parser_export.add_argument(
+    '-p', '--port',
+    help='port to use as the base for this application in exported config file',
+    default=5000, type=int, metavar='N')
 parser_export.add_argument(
     '-c', '--concurrency',
     help='number of each process type to run.',


### PR DESCRIPTION
This fixes one of the issues mentioned in https://github.com/nickstenning/honcho/issues/98

> The help doesn't have a description for the -p/--port option. readthedocs is better here (unless the "Should be a multiple of 1000" bit isn't true, which I didn't verify).
