### PR TITLE
Fix broken tox docs target

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -6,7 +6,7 @@ API Documentation
     :undoc-members:
     :show-inheritance:
 
-.. automodule:: honcho.procfile
+.. automodule:: honcho.environ
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,7 +48,7 @@ copyright = u'2014, Nick Stenning'
 # built documents.
 #
 # The short X.Y version.
-from ..honcho import __version__
+from honcho import __version__
 version = __version__
 # The full version, including alpha/beta/rc tags.
 release = __version__


### PR DESCRIPTION
This change prevents me from getting the following errors:

```
$ tox -e docs
GLOB sdist-make: /Users/marca/dev/git-repos/honcho/setup.py
docs inst-nodeps: /Users/marca/dev/git-repos/honcho/.tox/dist/honcho-0.5.0.zip
docs runtests: PYTHONHASHSEED='3860990299'
docs runtests: commands[0] | sphinx-build -W -b html -d /Users/marca/dev/git-repos/honcho/.tox/docs/tmp/doctrees .  /Users/marca/dev/git-repos/honcho/.tox/docs/tmp/html
Running Sphinx v1.3b1
making output directory...

Exception occurred:
  File "conf.py", line 51, in <module>
    from ..honcho import __version__
KeyError: "'__name__' not in globals"
The full traceback has been saved in /var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/sphinx-err-bu6qxnzx.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://bitbucket.org/birkenfeld/sphinx/issues/>. Thanks!
ERROR: InvocationError: '/Users/marca/dev/git-repos/honcho/.tox/docs/bin/sphinx-build -W -b html -d /Users/marca/dev/git-repos/honcho/.tox/docs/tmp/doctrees .  /Users/marca/dev/git-repos/honcho/.tox/docs/tmp/html'
```

and:

```
Warning, treated as error:
/Users/marca/dev/git-repos/honcho/doc/api.rst:9: WARNING: autodoc: failed to import module 'honcho.procfile'; the following exception was raised:
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/honcho/.tox/docs/lib/python3.4/site-packages/sphinx/ext/autodoc.py", line 378, in import_object
    __import__(self.modname)
ImportError: No module named 'honcho.procfile'
```
