### PR TITLE
Fix the tox coverage target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - pypy
 install:
   - pip install -r requirements_dev.txt
-  - pip install coverage flake8 nose pep8-naming
+  - pip install 'coverage<3.999.999' flake8 nose pep8-naming
   - pip install coveralls
 script:
   - nosetests --with-coverage --cover-branches --cover-package honcho honcho/test/unit

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
 [testenv:coverage]
 deps =
     {[testenv]deps}
-    coverage
+    coverage<3.999.999
 commands =
     pip install -e .[export]
     nosetests --with-coverage --cover-branches --cover-package honcho {posargs:honcho/test/unit}


### PR DESCRIPTION
This change prevents the following error:

```
$ tox -e coverage
...
coverage runtests: commands[1] | nosetests --with-coverage --cover-branches --cover-package honcho honcho/test/unit
...........................E......................
======================================================================
ERROR: Failure: ImportError (cannot import name 'coverage')
----------------------------------------------------------------------
Traceback (most recent call last):
  ...
  File "/Users/marca/dev/git-repos/honcho/honcho/test/unit/test_manager.py", line 10, in <module>
    multiprocessing.Process = monkeypatch_process_for_coverage(multiprocessing.Process)
  File "/Users/marca/dev/git-repos/honcho/honcho/test/helpers.py", line 87, in monkeypatch_process_for_coverage
    from coverage.control import coverage
ImportError: cannot import name 'coverage'
```

It seems that in `coverage==4.0a1` (which is somehow in my company's local devpi server but not on PyPI now; wonder if @nedbat pushed it to PyPI and then had second thoughts?), "coverage" (lowercase 'c') changed to "Coverage" (uppercase 'c'). So it seems wise to pin to coverage 3.x for now.
