### PR TITLE
export supervisord: Remove shell from command

### DIFF
--- a/honcho/data/export/supervisord/supervisord.conf
+++ b/honcho/data/export/supervisord/supervisord.conf
@@ -1,6 +1,6 @@
 {% for name,command,full_name,num,env in processes -%}
 [program:{{ full_name }}]
-command={{ shell }} -c '{{ command }}'
+command={{ command }}
 autostart=true
 autorestart=true
 stopsignal=QUIT

--- a/honcho/test/unit/test_export_supervisord.py
+++ b/honcho/test/unit/test_export_supervisord.py
@@ -41,9 +41,7 @@ class TestExportSupervisord(TestCase):
 
         self.assertTrue(parser.has_section(section))
         self.assertEqual(DEFAULT_OPTIONS.user, parser.get(section, "user"))
-        self.assertEqual("{0} -c 'python simple.py'"
-                         .format(DEFAULT_OPTIONS.shell),
-                         parser.get(section, "command"))
+        self.assertEqual("python simple.py", parser.get(section, "command"))
 
     def test_supervisord_concurrency(self):
         procfile = get_procfile("Procfile.simple")


### PR DESCRIPTION
This matches Foreman's behavior (see #109) and also matches what the Honcho docs say at https://honcho.readthedocs.org/en/latest/export.html:

```
-s SHELL, --shell SHELL
    Specify the shell that should run the application.
    Only used for upstart.
```
