### PR TITLE
export: Default user name to app name

### DIFF
--- a/honcho/command.py
+++ b/honcho/command.py
@@ -78,16 +78,7 @@ def command_export(args):
     if args.log == "/var/log/APP":
         args.log = args.log.replace('APP', args.app)
 
-    if args.user is None:
-        if compat.ON_WINDOWS:
-            args.user = os.environ.get('USERNAME')
-        else:
-            args.user = os.environ.get('USER')
-
-    if args.user is None:
-        raise CommandError('Could not automatically deduce user: please '
-                           'supply the -u/--user option.')
-
+    args.user = args.user or args.app
     args.app_root = os.path.abspath(args.app_root)
 
     procfile_path = _procfile_path(args.app_root, args.procfile)

--- a/honcho/export/base.py
+++ b/honcho/export/base.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import os
-import pwd
 import sys
 from pkg_resources import resource_filename
 
@@ -27,15 +26,6 @@ class BaseExport(object):
         self.environment = environment
         self.concurrency = concurrency
 
-        try:
-            user_entry = pwd.getpwnam(options.user)
-        except KeyError:
-            raise CommandError("No such user available: {0}"
-                               .format(options.user))
-
-        self.uid = user_entry.pw_uid
-        self.gid = user_entry.pw_gid
-
     def _mkdir(self, directory):
         if os.path.exists(directory):
             return
@@ -45,14 +35,6 @@ class BaseExport(object):
             print(e)
             raise CommandError("Can not create {0}"
                                .format(directory))
-
-    def _chown(self, filename):
-        try:
-            os.chown(filename, self.uid, self.gid)
-        except OSError:
-            raise CommandError("Can not chown {0} to {1}"
-                               .format(self.options.log,
-                                       self.options.user))
 
     def _write(self, filename, content):
         path = os.path.join(self.options.location, filename)


### PR DESCRIPTION
and remove code for deducing current user.

This makes the behavior consistent with Foreman (see #109). Also, I think folks are more likely to want to run their apps as some app-specific user, not as the user running export. In fact, some folks may run `honcho export` on a completely different box than where they end up running the applications.
