### PR TITLE
export: Display message about writing file

### DIFF
--- a/honcho/export/base.py
+++ b/honcho/export/base.py
@@ -90,6 +90,7 @@ class BaseExport(object):
                             self.concurrency)
 
         for name, content in files:
+            print("[honcho export] writing: %s" % name, file=sys.stderr)
             self._write(name, content)
 
         return files

--- a/honcho/test/integration/test_export.py
+++ b/honcho/test/integration/test_export.py
@@ -69,7 +69,7 @@ class TestExport(TestCase):
 
             self.assertEqual(ret, 0)
             self.assertEqual(out, '')
-            self.assertEqual(err, '')
+            self.assertEqual(err, '[honcho export] writing: fixtures.conf\n')
             self.assertTrue(path.exists(path.join(temp_dir, 'fixtures.conf')))
 
     def test_export_upstart(self):
@@ -83,7 +83,9 @@ class TestExport(TestCase):
 
             self.assertEqual(ret, 0)
             self.assertEqual(out, '')
-            self.assertEqual(err, '')
+            self.assertEqual(err, '[honcho export] writing: fixtures-foo.conf\n'
+                                  '[honcho export] writing: fixtures-foo-1.conf\n'
+                                  '[honcho export] writing: fixtures.conf\n')
             for filename in ('fixtures.conf', 'fixtures-foo.conf', 'fixtures-foo-1.conf'):
                 self.assertTrue(path.exists(path.join(temp_dir, filename)),
                                 'File %r was not generated!' % filename)


### PR DESCRIPTION
This makes it consistent with Foreman (See #109) and is just nice for the user to know what is happening. Looks like this:

```
[marca@marca-mac2 export_test]$ honcho export supervisord .
[honcho export] writing: export_test.conf

[marca@marca-mac2 export_test]$ honcho export upstart .
[honcho export] writing: export_test-ansvc.conf
[honcho export] writing: export_test-ansvc-1.conf
[honcho export] writing: export_test.conf
```
