### PR TITLE
export supervisord: Improve process numbering

### DIFF
--- a/honcho/data/export/supervisord/supervisord.conf
+++ b/honcho/data/export/supervisord/supervisord.conf
@@ -1,5 +1,5 @@
 {% for name,command,full_name,num,env in processes -%}
-[program:{{ full_name }}]
+[program:{{ full_name }}-{{ num }}]
 command={{ shell }} -c '{{ command }}'
 autostart=true
 autorestart=true
@@ -11,4 +11,4 @@ directory={{ app_root }}
 environment={% for key,value in env %}{{ key }}={{ value }}{% if not loop.last %},{% endif %}{% endfor %}
 {% endfor %}
 [group:{{ app }}]
-programs={% for name,command,full_name,num,env in processes %}{{ full_name }}{% if not loop.last %},{% endif %}{% endfor %}
+programs={% for name,command,full_name,num,env in processes %}{{ full_name }}-{{ num }}{% if not loop.last %},{% endif %}{% endfor %}

--- a/honcho/export/supervisord.py
+++ b/honcho/export/supervisord.py
@@ -8,12 +8,11 @@ class Export(BaseExport):
         processes = []
         port = options.port
         for name, cmd in procfile.processes.items():
-            for num in compat.xrange(0, concurrency[name]):
+            for num in compat.xrange(1, concurrency[name] + 1):
                 full_name_parts = [options.app, name]
                 env = environment.copy()
                 if concurrency[name] > 1:
                     env['PORT'] = str(port + num)
-                    full_name_parts.append(str(num))
                 else:
                     env['PORT'] = str(port)
                 processes.append((

--- a/honcho/test/unit/test_export_supervisord.py
+++ b/honcho/test/unit/test_export_supervisord.py
@@ -37,7 +37,7 @@ class TestExportSupervisord(TestCase):
         parser = compat.ConfigParser()
         parser.readfp(compat.StringIO(contents))
 
-        section = "program:app-foo"
+        section = "program:app-foo-1"
 
         self.assertTrue(parser.has_section(section))
         self.assertEqual(DEFAULT_OPTIONS.user, parser.get(section, "user"))
@@ -56,7 +56,7 @@ class TestExportSupervisord(TestCase):
         parser = compat.ConfigParser()
         parser.readfp(compat.StringIO(contents))
 
-        for job_index in compat.xrange(4):
+        for job_index in compat.xrange(1, 5):
             section = "program:app-foo-{0}".format(job_index)
             self.assertTrue(parser.has_section(section))
             self.assertEqual('PORT="{0}"'
@@ -65,4 +65,4 @@ class TestExportSupervisord(TestCase):
 
         self.assertEqual(
             parser.get("group:app", "programs"),
-            ",".join("app-foo-{0}".format(i) for i in compat.xrange(4)))
+            ",".join("app-foo-{0}".format(i) for i in compat.xrange(1, 5)))


### PR DESCRIPTION
More consistent with Foreman (see #109).
1. Make numbering 1-based instead of 0-based.
2. Include number in program name.

I also moved the append of `num` to `full_name` from the Python code to the template. I think that this is better, because it will allow folks to control whether or not it gets appended using a custom template (which is hopefully coming soon... :smile:) (see issue #88; PR coming soon...)
##### Example:

```
[marca@marca-mac2 export_test]$ honcho export supervisord .
[marca@marca-mac2 export_test]$ cat export_test.conf
[program:export_test-ansvc-1]
command=/bin/sh -c 'bin/ansvc start'
autostart=true
autorestart=true
stopsignal=QUIT
stdout_logfile=/var/log/export_test/ansvc-1.log
stderr_logfile=/var/log/export_test/ansvc-1.error.log
user=marca
directory=/Users/marca/dev/git-repos/honcho/export_test
environment=PORT="5000"

[group:export_test]
programs=export_test-ansvc-1
```

We are getting closer to making honcho's output match foreman.

```
[marca@marca-mac2 export_test]$ ~/dev/git-repos/foreman/bin/foreman export -a export_test supervisord . && mv export_test.conf foreman.conf
[foreman export] writing: export_test.conf
[marca@marca-mac2 export_test]$ honcho export supervisord . && mv export_test.conf honcho.conf
[marca@marca-mac2 export_test]$ diff -u foreman.conf honcho.conf
diff --git a/foreman.conf b/honcho.conf
index 869012e..9371eae 100644
--- a/foreman.conf
+++ b/honcho.conf
@@ -1,11 +1,11 @@
 [program:export_test-ansvc-1]
-command=bin/ansvc start
+command=/bin/sh -c 'bin/ansvc start'
 autostart=true
 autorestart=true
 stopsignal=QUIT
 stdout_logfile=/var/log/export_test/ansvc-1.log
 stderr_logfile=/var/log/export_test/ansvc-1.error.log
-user=export_test
+user=marca
 directory=/Users/marca/dev/git-repos/honcho/export_test
 environment=PORT="5000"
```

The `command` discrepancy is handled by PR #110.
The `user` discrepancy is handled by PR #111.
Then we will have handled all of the differences mentioned in issue #109.
