### PR TITLE
Export: Add custom template support

### DIFF
--- a/doc/export.rst
+++ b/doc/export.rst
@@ -32,6 +32,9 @@ Options
     -l DIR, --log DIR
         Specify the directory to place process logs in.
 
+    -t TEMPLATE, --template TEMPLATE
+        Specify alternate template to use for creating export files.
+
 
 Examples
 --------

--- a/honcho/command.py
+++ b/honcho/command.py
@@ -97,6 +97,7 @@ def command_export(args):
         'log': args.log,
         'shell': args.shell,
         'user': args.user or args.app,
+        'template': args.template,
     }
 
     _mkdir(args.location)
@@ -133,6 +134,10 @@ parser_export.add_argument(
     '-s', '--shell',
     help="the shell that should run the application",
     default='/bin/sh', type=str)
+parser_export.add_argument(
+    '-t', '--template',
+    help="alternate template to use for creating export files",
+    default=None, type=str)
 parser_export.add_argument(
     'format',
     help="format to export to; one of %(choices)s",

--- a/honcho/export/base.py
+++ b/honcho/export/base.py
@@ -46,7 +46,11 @@ def dashrepl(value):
 
 def _default_template_env():
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader(__name__, 'templates'))
+        loader=jinja2.ChoiceLoader([
+            jinja2.PackageLoader(__name__, 'templates'),
+            jinja2.FileSystemLoader('/'),
+        ])
+    )
     env.filters['shellquote'] = shellquote
     env.filters['dashrepl'] = dashrepl
     return env

--- a/honcho/export/supervisord.py
+++ b/honcho/export/supervisord.py
@@ -5,5 +5,6 @@ class Export(BaseExport):
     def render(self, processes, context):
         context['processes'] = processes
         filename = "{0}.conf".format(context['app'])
-        template = self.get_template('supervisord/supervisord.conf')
-        return [(filename, template.render(context))]
+        template_name = context.get('template') or 'supervisord/supervisord.conf'
+        jinja2_template = self.get_template(template_name)
+        return [(filename, jinja2_template.render(context))]

--- a/honcho/test/fixtures/custom_supervisord.conf
+++ b/honcho/test/fixtures/custom_supervisord.conf
@@ -1,0 +1,22 @@
+# Generated from custom template: honcho/test/fixtures/custom_supervisord.conf
+{% for p in processes %}
+[program:{{ p.name|dashrepl }}]
+command={{ shell }} -c '{{ p.cmd }}'
+autostart=true
+autorestart=true
+stopsignal=QUIT
+stdout_logfile={{ log }}/{{ p.name|dashrepl }}.log
+stderr_logfile={{ log }}/{{ p.name|dashrepl }}.error.log
+user={{ user }}
+directory={{ app_root }}
+environment=
+    {%- for key,value in p.env.items() -%}
+    {{ key }}={{ value|shellquote }}
+    {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+{%- endfor %}
+
+[group:{{ app }}]
+programs={% for p in processes -%}
+    {{ p.name|dashrepl }}{% if not loop.last %},{% endif %}
+{%- endfor %}


### PR DESCRIPTION
This adds the ability to use a custom template when exporting to supervisord.

Fixes: GH-88

##### Example:

```
$ honcho export supervisord . -t my_supervisord_template.conf.jinja2

$ cat export_test.conf
# *****************************************************
# This is a custom supervisord template for honcho
# blah blah blah
# *****************************************************

[program:export_test-ansvc]
MONKEY=YES
command=/bin/sh -c 'bin/ansvc start'
autostart=true
autorestart=true
stopsignal=QUIT
stdout_logfile=/var/log/export_test/ansvc-0.log
stderr_logfile=/var/log/export_test/ansvc-0.error.log
user=marca
directory=/Users/marca/dev/git-repos/honcho/export_test
environment=PORT="5000"

[group:export_test]
programs=export_test-ansvc
```