### PR TITLE
Flush output after each line for Python 3

### DIFF
--- a/honcho/printer.py
+++ b/honcho/printer.py
@@ -44,6 +44,8 @@ class Printer(object):
             if message.colour:
                 prefix = _colour_string(message.colour, prefix)
             self.output.write(prefix + line + "\n")
+            if hasattr(self.output, 'flush'):
+                self.output.flush()
 
 
 def _ansi(code):


### PR DESCRIPTION
For some reason, output is getting buffered on Python 3.

Fixes GH-136

Cc: @jlirochon