### PR TITLE
Allow more types of punctuation in .env values

### DIFF
--- a/honcho/environ.py
+++ b/honcho/environ.py
@@ -78,13 +78,15 @@ def parse(content):
     values = {}
     for line in content.splitlines():
         lexer = shlex.shlex(line, posix=True)
-        lexer.wordchars += '/.+-():'
         tokens = list(lexer)
 
         # parses the assignment statement
-        if len(tokens) != 3:
+        if len(tokens) < 3:
             continue
-        name, op, value = tokens
+
+        name, op = tokens[:2]
+        value = ''.join(tokens[2:])
+
         if op != '=':
             continue
         if not re.match(r'[A-Za-z_][A-Za-z_0-9]*', name):

--- a/honcho/test/unit/test_environ.py
+++ b/honcho/test/unit/test_environ.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import textwrap
 from ..helpers import TestCase
 
@@ -66,6 +68,41 @@ ENVFILE_FIXTURES = [
         """,
         {'MYVAR': '"escaped"'}
     ],
+    [
+        # At-sign in value
+        r"""
+        MYVAR=user@domain.com
+        """,
+        {'MYVAR': 'user@domain.com'}
+    ],
+    [
+        # Much punctuation in value
+        r"""
+        MYVAR=~pun|u@|0n$=
+        """,
+        {'MYVAR': '~pun|u@|0n$='}
+    ],
+    [
+        # Unicode values
+        r"""
+        MYVAR=⋃ñᴉ—☪ó∂ǝ
+        """,
+        {'MYVAR': '⋃ñᴉ—☪ó∂ǝ'}
+    ],
+    [
+        # Unicode keys
+        r"""
+        ṀẎṾẠṚ=value
+        """,
+        {}
+    ],
+    [
+        # Quoted space in value
+        r"""
+        MYVAR='sp ace'
+        """,
+        {'MYVAR': 'sp ace'}
+    ]
 ]
 
 PROCFILE_FIXTURES = [


### PR DESCRIPTION
Prior to using shlex to parse the .env file in 0.6.0, the regex parser seemed to allow any printable character in an environment variable value. The implementation of the shlex parser only allows a-zA-Z0-9_/.+-(): characters (with special rules for quotes). This patch brings the behavior closer to the original regex parser, allowing values to include any non-whitespace printable character except = and \ (with special rules for quotes).

In my case, allowing @ in environment variables was crucial for me to store my postgreSQL URI in an environment variable (e.g. DATABASE_URL=postgres://user:pass@domain.com:port/database) 