### PR TITLE
Fix stop/ start issue #131

### DIFF
--- a/honcho/export/templates/upstart/process.conf
+++ b/honcho/export/templates/upstart/process.conf
@@ -1,9 +1,13 @@
-start on starting {{ group_name }}
-stop on stopping {{ group_name }}
+start on starting {{app}}-{{name}}
+stop on stopping {{app}}-{{name}}
 respawn
 
-exec su - {{ user }} -s {{ shell }} -c 'cd {{ app_root }};
-{%- for k, v in process.env.items() -%}
-  export {{ k }}={{ v | shellquote }};
-{%- endfor -%}
-{{ process.cmd }} >> {{ log }}/{{ process.name|dashrepl }}.log 2>&1'
+chdir {{app_root}}
+setuid {{ user }}
+
+{% for var, val in environment.iteritems() %}env {{var|upper}}="{{val}}"
+{% endfor %}
+
+script
+  exec {{ command }} >> {{ log }}/{{ name }}-{{ num }}.log 2>&1
+end script


### PR DESCRIPTION
This approach stops child processing hanging with exported upstart process by leveraging `setuid` (http://upstart.ubuntu.com/cookbook/#setuid). `service {app} restart` now works correctly for me.
