### PR TITLE
Fix a bug when honcho silently ignores environment file

### DIFF
--- a/honcho/command.py
+++ b/honcho/command.py
@@ -72,7 +72,7 @@ def command_export(args):
 
     procfile_path = _procfile_path(args.app_root, args.procfile)
     procfile = _procfile(procfile_path)
-    env = _read_env(procfile_path, args.env)
+    env = _read_env(args.app_root, args.env)
     concurrency = _parse_concurrency(args.concurrency)
     port = _choose_port(args, env)
 
@@ -154,8 +154,7 @@ parser_help.add_argument('task', help='task to show help for', nargs='?')
 
 
 def command_run(args):
-    procfile_path = _procfile_path(args.app_root, args.procfile)
-    os.environ.update(_read_env(procfile_path, args.env))
+    os.environ.update(_read_env(args.app_root, args.env))
 
     if compat.ON_WINDOWS:
         # do not quote on Windows, subprocess will handle it for us
@@ -185,7 +184,7 @@ def command_start(args):
     procfile = _procfile(procfile_path)
 
     concurrency = _parse_concurrency(args.concurrency)
-    env = _read_env(procfile_path, args.env)
+    env = _read_env(args.app_root, args.env)
     quiet = _parse_quiet(args.quiet)
     port = _choose_port(args, env)
 
@@ -288,8 +287,7 @@ def _procfile(filename):
     return procfile
 
 
-def _read_env(procfile_path, env):
-    app_root = os.path.dirname(procfile_path)
+def _read_env(app_root, env):
     files = [e.strip() for e in env.split(',')]
     content = []
     for envfile in files:
@@ -297,7 +295,7 @@ def _read_env(procfile_path, env):
             with open(os.path.join(app_root, envfile)) as f:
                 content.append(f.read())
         except IOError:
-            pass
+            log.warn('Could not read environment file %s', envfile)
 
     return environ.parse('\n'.join(content))
 


### PR DESCRIPTION
If Procfile is not located in the app root directory honcho uses incorrect
path and silently ignores the error. The fix is to pass app_root directly
to _read_env instead of deriving it from procfile_path