### PR TITLE
Do not warn on non-tty sys.stdout

### DIFF
--- a/honcho/command.py
+++ b/honcho/command.py
@@ -357,6 +357,9 @@ def _check_output_encoding():
     no_encoding = sys.stdout.encoding is None
     utf8 = codecs.lookup('utf8')
 
+    if not sys.stdout.isatty():
+        return
+
     if no_encoding or codecs.lookup(sys.stdout.encoding) != utf8:
         log.warn('Your terminal is not configured to receive UTF-8 encoded '
                  'text. Please adjust your locale settings or force UTF-8 '


### PR DESCRIPTION
When piping to other commands such as grep a warning was displayed since
the pipe is not utf-8.