### PR TITLE
Add a system print to tell a user how to stop.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - 3.4
   - pypy
 install:
-  - pip install coverage coveralls flake8 nose pep8-naming wheel
+  - pip install coverage==3.7.1 coveralls flake8 nose pep8-naming wheel
   - pip wheel .
   - pip install --find-links=$PWD/wheelhouse honcho[export]
 script:

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,3 +31,4 @@ Contributors
 * Miguel Grinberg
 * Pepijn de Vos
 * Philippe Ombredanne
+* Matt Layman

--- a/honcho/manager.py
+++ b/honcho/manager.py
@@ -90,6 +90,7 @@ class Manager(object):
         signal.signal(signal.SIGTERM, _terminate)
         signal.signal(signal.SIGINT, _terminate)
 
+        self._system_print("Press Ctrl-C to stop.")
         self._start()
 
         exit = False

--- a/honcho/test/unit/test_manager.py
+++ b/honcho/test/unit/test_manager.py
@@ -240,9 +240,10 @@ class TestManager(TestCase):
     def test_printer_receives_messages_in_correct_order(self):
         self.run_history('one')
         self.p.fetch_lines()
-        self.assertEqual('foo started (pid=123)\n', self.p.lines_local[0].data)
-        self.assertEqual(b'hello, world!\n', self.p.lines_local[1].data)
-        self.assertEqual('foo stopped (rc=0)\n', self.p.lines_local[2].data)
+        self.assertEqual('Press Ctrl-C to stop.', self.p.lines_local[0].data)
+        self.assertEqual('foo started (pid=123)\n', self.p.lines_local[1].data)
+        self.assertEqual(b'hello, world!\n', self.p.lines_local[2].data)
+        self.assertEqual('foo stopped (rc=0)\n', self.p.lines_local[3].data)
 
     def test_printer_receives_lines_multi_process(self):
         self.run_history('two')


### PR DESCRIPTION
The documentation doesn't tell a user to stop once they've started. For people doing command line stuff for a long time, this may seem obvious. I thought it would be nice to tell a user what to do when they want to quit.

Thanks for honcho! It's been really helpful for the startup I work at.