### PR TITLE
Fix quoting of special env var values in Upstart configs

### DIFF
--- a/honcho/export/templates/upstart/process.conf
+++ b/honcho/export/templates/upstart/process.conf
@@ -2,8 +2,7 @@ start on starting {{ group_name }}
 stop on stopping {{ group_name }}
 respawn
 
-exec su - {{ user }} -s {{ shell }} -c 'cd {{ app_root }};
-{%- for k, v in process.env.items() -%}
-  export {{ k }}={{ v | shellquote }};
-{%- endfor -%}
-exec {{ process.cmd }} >> {{ log }}/{{ process.name|dashrepl }}.log 2>&1'
+{% for k, v in process.env.items() -%}
+env {{ k }}={{ v | shellquote }}
+{% endfor %}
+exec su - {{ user }} -m -s {{ shell }} -c 'cd {{ app_root }}; exec {{ process.cmd }} >> {{ log }}/{{ process.name|dashrepl }}.log 2>&1'

--- a/tests/integration/test_export.py
+++ b/tests/integration/test_export.py
@@ -37,3 +37,37 @@ def test_export_upstart(testenv):
                      'trunk-web-1.conf'):
         expected = testenv.path('elephant', filename)
         assert os.path.exists(expected)
+
+
+@pytest.mark.parametrize('testenv', [{
+    'Procfile': "web: python web.py",
+    '.env': """
+NORMAL=ok
+SQ_SPACES='sqspace sqspace'
+DQ_SPACES="dqspace dqspace"
+SQ="it's got single quotes"
+DQ='it has "double" quotes'
+EXCL='an exclamation mark!'
+SQ_DOLLAR='costs $UNINTERPOLATED amount'
+DQ_DOLLAR="costs $UNINTERPOLATED amount"
+"""
+}], indirect=True)
+def test_export_upstart_environment(testenv):
+    ret, out, err = testenv.run_honcho([
+        'export',
+        'upstart',
+        testenv.path('test'),
+        '-a', 'envvars',
+    ])
+
+    assert ret == 0
+
+    lines = open(testenv.path('test', 'envvars-web-1.conf')).readlines()
+    assert 'env NORMAL=ok\n' in lines
+    assert "env SQ_SPACES='sqspace sqspace'\n" in lines
+    assert "env DQ_SPACES='dqspace dqspace'\n" in lines
+    assert "env SQ='it'\"'\"'s got single quotes'\n" in lines
+    assert "env DQ='it has \"double\" quotes'\n" in lines
+    assert "env EXCL='an exclamation mark!'\n" in lines
+    assert "env SQ_DOLLAR='costs $UNINTERPOLATED amount'\n" in lines
+    assert "env DQ_DOLLAR='costs $UNINTERPOLATED amount'\n" in lines


### PR DESCRIPTION
As reported by #151, the quoting of environment variable values in Upstart configs is currently broken in the general case.

Correctly quoting variable values in the current context (i.e. already inside single quotes) is possible, but extremely messy, and results in hugely nested quotes when those values contain single quotes.

Instead, move the definition of the environment variables into the body of the Upstart config using the `env` directive, and add the `-m` option to `su(1)` so that environment variables are passed through to the shell process.

Closes #151.
Closes #154.