### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ The 30-second version:
 For more detail and an explanation of the circumstances in which Honcho might
 be useful, consult the `Honcho documentation`_.
 
-.. _Honcho documentation: https://honcho.readthedocs.org/
+.. _Honcho documentation: https://honcho.readthedocs.io/
 
 License
 -------


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.