### PR TITLE
Expose process name in child environment.

### DIFF
--- a/doc/using_procfiles.rst
+++ b/doc/using_procfiles.rst
@@ -39,6 +39,12 @@ Honcho::
     PROCFILE=Procfile
     EOF
 
+In addition to the variables specified in your ``.env`` file, the subprocess
+environment will also contain a ``HONCHO_PROCESS_NAME`` variable that will be
+set to a unique string composed of the process name as defined in the Procfile
+and an integer counter that is incremented for each concurrent process of the
+same type, for example: ``web.1``, ``web.2``, ``queue.1``, etc.
+
 As shown, you may choose to specify your Procfile in the ``.env`` file.  This
 takes priority over the default Procfile, but you can still use ``-f`` to replace
 which Procfile to use.

--- a/honcho/environ.py
+++ b/honcho/environ.py
@@ -129,7 +129,7 @@ def expand_processes(processes, concurrency=None, env=None, quiet=None, port=Non
             n = "{0}.{1}".format(name, i + 1)
             c = cmd
             q = name in quiet
-            e = {}
+            e = {'HONCHO_PROCESS_NAME': n}
             if env is not None:
                 e.update(env)
             if port is not None:

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -246,38 +246,38 @@ def test_expand_processes_command():
 
 def test_expand_processes_port_not_defaulted():
     p = ep(("foo", "some command"))
-    assert p[0].env == {}
+    assert "PORT" not in p[0].env
 
 
 def test_expand_processes_port():
     p = ep(("foo", "some command"), port=8000)
-    assert p[0].env == {"PORT": "8000"}
+    assert p[0].env["PORT"] == "8000"
 
 
 def test_expand_processes_port_multiple():
     p = ep(("foo", "some command"),
            ("bar", "another command"),
            port=8000)
-    assert p[0].env == {"PORT": "8000"}
-    assert p[1].env == {"PORT": "8100"}
+    assert p[0].env["PORT"] == "8000"
+    assert p[1].env["PORT"] == "8100"
 
 
 def test_expand_processes_port_from_env():
     p = ep(("foo", "some command"),
            ("bar", "another command"),
            env={"PORT": 8000})
-    assert p[0].env == {"PORT": "8000"}
-    assert p[1].env == {"PORT": "8100"}
+    assert p[0].env["PORT"] == "8000"
+    assert p[1].env["PORT"] == "8100"
 
 
 def test_expand_processes_port_from_env_coerced_to_number():
     p = ep(("foo", "some command"), env={"PORT": "5000"})
-    assert p[0].env == {"PORT": "5000"}
+    assert p[0].env["PORT"] == "5000"
 
 
 def test_expand_processes_port_from_env_overrides():
     p = ep(("foo", "some command"), env={"PORT": 5000}, port=8000)
-    assert p[0].env == {"PORT": "5000"}
+    assert p[0].env["PORT"] == "5000"
 
 
 def test_expand_processes_port_concurrency():
@@ -285,11 +285,11 @@ def test_expand_processes_port_concurrency():
            ("bar", "another command"),
            concurrency={"foo": 3, "bar": 2},
            port=4000)
-    assert p[0].env == {"PORT": "4000"}
-    assert p[1].env == {"PORT": "4001"}
-    assert p[2].env == {"PORT": "4002"}
-    assert p[3].env == {"PORT": "4100"}
-    assert p[4].env == {"PORT": "4101"}
+    assert p[0].env["PORT"] == "4000"
+    assert p[1].env["PORT"] == "4001"
+    assert p[2].env["PORT"] == "4002"
+    assert p[3].env["PORT"] == "4100"
+    assert p[4].env["PORT"] == "4101"
 
 
 def test_expand_processes_quiet():
@@ -320,3 +320,14 @@ def test_expand_processes_env_multiple():
     assert p[0].env["DEBUG"] == "false"
     assert p[1].env["ANIMAL"] == "giraffe"
     assert p[1].env["DEBUG"] == "false"
+
+
+def test_set_env_process_name():
+    p = ep(("foo", "some command"),
+           ("bar", "another command"),
+           concurrency={"foo": 3, "bar": 2})
+    assert p[0].env["HONCHO_PROCESS_NAME"] == "foo.1"
+    assert p[1].env["HONCHO_PROCESS_NAME"] == "foo.2"
+    assert p[2].env["HONCHO_PROCESS_NAME"] == "foo.3"
+    assert p[3].env["HONCHO_PROCESS_NAME"] == "bar.1"
+    assert p[4].env["HONCHO_PROCESS_NAME"] == "bar.2"


### PR DESCRIPTION
This exposes process name (eg. `"web.1"`, `"web.2"`, `"queue_worker.1"`, ...) as `HONCHO_PROCESS_NAME` environment variable in managed child processes.

This is mostly useful for logging purposes.
