### PR TITLE
Use upstart's native logging features

### DIFF
--- a/honcho/export/templates/upstart/master.conf
+++ b/honcho/export/templates/upstart/master.conf
@@ -1,12 +1,3 @@
-pre-start script
-
-bash << "EOF"
-  mkdir -p {{log}}
-  chown -R {{user}} {{log}}
-EOF
-
-end script
-
 start on (started network-interface
           or started network-manager
           or started networking)

--- a/honcho/export/templates/upstart/process.conf
+++ b/honcho/export/templates/upstart/process.conf
@@ -5,4 +5,4 @@ respawn
 {% for k, v in process.env.items() -%}
 env {{ k }}={{ v | shellquote }}
 {% endfor %}
-exec su - {{ user }} -m -s {{ shell }} -c 'cd {{ app_root }}; exec {{ process.cmd }} >> {{ log }}/{{ process.name|dashrepl }}.log 2>&1'
+exec su - {{ user }} -m -s {{ shell }} -c 'cd {{ app_root }}; exec {{ process.cmd }}'


### PR DESCRIPTION
Removes from the upstart export template the custom log location in favor of using upstart's built-in logging collection, compression, and rotation features. Addresses issue #180.
