### PR TITLE
Don't add ANSI color sequences on non-TTY outputs

### DIFF
--- a/honcho/printer.py
+++ b/honcho/printer.py
@@ -21,6 +21,15 @@ class Printer(object):
         self.time_format = time_format
         self.width = width
 
+        try:
+            # We only want to print coloured messages if the given output supports
+            # ANSI escape sequences. Usually, testing if it is a TTY is safe enough.
+            self._colours_supported = self.output.isatty()
+        except AttributeError:
+            # If the given output does not implement isatty(), we assume that it
+            # is not able to handle ANSI escape sequences.
+            self._colours_supported = False
+
     def write(self, message):
         if message.type != 'line':
             raise RuntimeError('Printer can only process messages of type "line"')
@@ -41,7 +50,7 @@ class Printer(object):
         for line in string.splitlines():
             time_formatted = message.time.strftime(self.time_format)
             prefix = '{time} {name}| '.format(time=time_formatted, name=name)
-            if message.colour:
+            if self._colours_supported and message.colour:
                 prefix = _colour_string(message.colour, prefix)
             self.output.write(prefix + line + "\n")
 

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -30,6 +30,12 @@ class FakeOutput(object):
         return "".join(self.out)
 
 
+class FakeTTY(FakeOutput):
+
+    def isatty(self):
+        return True
+
+
 class TestPrinter(object):
     def test_write(self):
         out = FakeOutput()
@@ -80,8 +86,14 @@ class TestPrinter(object):
         p.write(fake_message("narcissist\n", name="oop"))
         assert out.string() == "12:42:00 oop    | narcissist\n"
 
-    def test_write_with_colour(self):
-        out = FakeOutput()
+    def test_write_with_colour_tty(self):
+        out = FakeTTY()
         p = Printer(output=out)
         p.write(fake_message("conflate\n", name="foo", colour="31"))
         assert out.string() == "\033[0m\033[31m12:42:00 foo | \033[0mconflate\n"
+
+    def test_write_with_colour_non_tty(self):
+        out = FakeOutput()
+        p = Printer(output=out)
+        p.write(fake_message("conflate\n", name="foo", colour="31"))
+        assert out.string() == "12:42:00 foo | conflate\n"


### PR DESCRIPTION
This adds a check to the Printer class so that it only adds ANSI color
codes to an output line when the output object passes a isatty() check.

This is advisable in situations where honcho's output is not written to
a terminal (e.g. redirected to a file, started as a systemd service,
started in a detached docker container, ...) and therefore would only
pollute the output target with non-interpreted ANSI escape sequences.
