### PR TITLE
Add self-explaining no-colour and no-prefix arguments

### DIFF
--- a/doc/using_procfiles.rst
+++ b/doc/using_procfiles.rst
@@ -67,30 +67,31 @@ To see the command line arguments accepted by Honcho, run it with the ``--help``
 option::
 
     $ honcho --help
-    usage: honcho [-h] [-v] [-e ENV] [-d APP_ROOT] [-f PROCFILE]
-                  {check,export,help,run,start} ...
+    usage: honcho [-h] [-e ENV] [-d DIR] [--no-colour] [--no-prefix] [-f FILE]
+                  [-v]
+                  {check,export,help,run,start,version} ...
 
     Manage Procfile-based applications
 
     optional arguments:
       -h, --help            show this help message and exit
+      -e ENV, --env ENV     environment file[,file] (default: .env)
+      -d DIR, --app-root DIR
+                            procfile directory (default: .)
+      --no-colour           Disables colours on output
+      --no-prefix           Disables logging prefix completely
+      -f FILE, --procfile FILE
+                            procfile path (default: Procfile)
       -v, --version         show program's version number and exit
 
-    common arguments:
-      -e ENV, --env ENV     Environment file[,file] (default: .env)
-      -d APP_ROOT, --app-root APP_ROOT
-                            Procfile directory (default: .)
-      -f PROCFILE, --procfile PROCFILE
-                            Procfile path (default: Procfile)
-
     tasks:
-      {check,export,help,run,start}
-        check               Validate your application's Procfile
-        export              Export the application to another process management
-                            format
-        help                Describe available tasks or one specific task
-        run                 Run a command using your application's environment
-        start               Start the application (or a specific PROCESS)
+      {check,export,help,run,start,version}
+        check               validate a Procfile
+        export              export a Procfile to another format
+        help                describe available tasks or one specific task
+        run                 run a command using your application's environment
+        start               start the application (or a specific PROCESS)
+        version             display honcho version
 
 
 You will notice that by default, Honcho will read a Procfile called

--- a/honcho/command.py
+++ b/honcho/command.py
@@ -10,6 +10,7 @@ from pkg_resources import iter_entry_points
 from honcho import __version__
 from honcho.process import Popen
 from honcho.manager import Manager
+from honcho.printer import Printer
 from honcho import compat, environ
 
 logging.basicConfig(format='%(asctime)s [%(process)d] [%(levelname)s] '
@@ -37,6 +38,12 @@ def _add_common_args(parser, with_defaults=False):
                         metavar='DIR',
                         default=(suppress or '.'),
                         help='procfile directory (default: .)')
+    parser.add_argument('--no-colour',
+                        action='store_true',
+                        help='Disables colours on output')
+    parser.add_argument('--no-prefix',
+                        action='store_true',
+                        help='Disables logging prefix completely')
     parser.add_argument('-f', '--procfile',
                         metavar='FILE',
                         default=suppress,
@@ -210,7 +217,9 @@ def command_start(args):
     else:
         processes = procfile.processes
 
-    manager = Manager()
+    manager = Manager(Printer(sys.stdout,
+                              colour=(not args.no_colour),
+                              prefix=(not args.no_prefix)))
 
     for p in environ.expand_processes(processes,
                                       concurrency=concurrency,

--- a/honcho/printer.py
+++ b/honcho/printer.py
@@ -56,8 +56,8 @@ class Printer(object):
             if self.prefix:
                 time_formatted = message.time.strftime(self.time_format)
                 prefix = '{time} {name}| '.format(time=time_formatted, name=name)
-            if self.colour and self._colours_supported and message.colour:
-                prefix = _colour_string(message.colour, prefix)
+                if self.colour and self._colours_supported and message.colour:
+                    prefix = _colour_string(message.colour, prefix)
             self.output.write(prefix + line + "\n")
 
 

--- a/honcho/printer.py
+++ b/honcho/printer.py
@@ -16,10 +16,14 @@ class Printer(object):
     def __init__(self,
                  output=sys.stdout,
                  time_format="%H:%M:%S",
-                 width=0):
+                 width=0,
+                 colour=True,
+                 prefix=True):
         self.output = output
         self.time_format = time_format
         self.width = width
+        self.colour = colour
+        self.prefix = prefix
 
         try:
             # We only want to print coloured messages if the given output supports
@@ -48,9 +52,11 @@ class Printer(object):
             string = message.data
 
         for line in string.splitlines():
-            time_formatted = message.time.strftime(self.time_format)
-            prefix = '{time} {name}| '.format(time=time_formatted, name=name)
-            if self._colours_supported and message.colour:
+            prefix = ''
+            if self.prefix:
+                time_formatted = message.time.strftime(self.time_format)
+                prefix = '{time} {name}| '.format(time=time_formatted, name=name)
+            if self.colour and self._colours_supported and message.colour:
                 prefix = _colour_string(message.colour, prefix)
             self.output.write(prefix + line + "\n")
 

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -97,3 +97,27 @@ class TestPrinter(object):
         p = Printer(output=out)
         p.write(fake_message("conflate\n", name="foo", colour="31"))
         assert out.string() == "12:42:00 foo | conflate\n"
+
+    def test_write_without_prefix_tty(self):
+        out = FakeTTY()
+        p = Printer(output=out, prefix=False, colour=True)
+        p.write(fake_message("paranoid android\n", name="foo", colour="31"))
+        assert out.string() == "paranoid android\n"
+
+    def test_write_without_prefix_and_colour_tty(self):
+        out = FakeTTY()
+        p = Printer(output=out, prefix=False, colour=False)
+        p.write(fake_message("paranoid android\n", name="foo", colour="31"))
+        assert out.string() == "paranoid android\n"
+
+    def test_write_without_colour_tty(self):
+        out = FakeTTY()
+        p = Printer(output=out, prefix=True, colour=False)
+        p.write(fake_message("paranoid android\n", name="foo", colour="31"))
+        assert out.string() == "12:42:00 foo | paranoid android\n"
+
+    def test_write_without_prefix_non_tty(self):
+        out = FakeOutput()
+        p = Printer(output=out, prefix=False)
+        p.write(fake_message("paranoid android\n", name="foo", colour="31"))
+        assert out.string() == "paranoid android\n"


### PR DESCRIPTION
Useful for situations where log draining/processing cannot be controlled (e.g. heroku)