### PR TITLE
Respawn processes with command line argument for start

### DIFF
--- a/honcho/command.py
+++ b/honcho/command.py
@@ -228,7 +228,7 @@ def command_start(args):
                                       port=port):
         e = os.environ.copy()
         e.update(p.env)
-        manager.add_process(p.name, p.cmd, quiet=p.quiet, env=e)
+        manager.add_process(p.name, p.cmd, quiet=p.quiet, env=e, respawn=args.respawn)
 
     manager.loop()
     sys.exit(manager.returncode)
@@ -246,6 +246,10 @@ parser_start.add_argument(
     '-c', '--concurrency',
     help='the number of each process type to run.',
     type=str, metavar='process=num,process=num')
+parser_start.add_argument(
+    '-r', '--respawn',
+    help='flag to enable process respawning.',
+    action='store_true')
 parser_start.add_argument(
     '-q', '--quiet',
     help='process names for which to suppress output',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import os
 import shutil
 import tempfile
+import time
+import subprocess
 from subprocess import Popen, PIPE
 
 import pytest
@@ -28,16 +30,24 @@ class TestEnv(object):
     def path(self, *args):
         return os.path.join(self.root, *args)
 
-    def run_honcho(self, args):
+    def run_honcho(self, args, respawn=False):
         cwd = os.getcwd()
         os.chdir(self.root)
 
         cmd = ['honcho']
         cmd.extend(args)
 
+        if respawn:
+            cmd.append('--respawn')
+
         # The below is mostly copy-pasted from subprocess.py's check_output (to
         # support python 2.6)
         process = Popen(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+
+        if respawn:
+            time.sleep(1)
+            process.send_signal(subprocess.signal.SIGTERM)
+
         output, error = process.communicate()
         retcode = process.returncode
 

--- a/tests/integration/test_start.py
+++ b/tests/integration/test_start.py
@@ -27,6 +27,18 @@ def test_start(testenv):
 
 
 @pytest.mark.parametrize('testenv', [{
+    'Procfile': 'foo: {0} test.py'.format(python_bin),
+    'test.py': script,
+}], indirect=True)
+def test_start_respawn(testenv):
+    ret, out, err = testenv.run_honcho(['start'], respawn=True)
+
+    assert ret != 0
+    assert 'elephant' in out
+    assert 'error output' in out
+
+
+@pytest.mark.parametrize('testenv', [{
     '.env': 'ANIMAL=giraffe',
     'Procfile': 'foo: {0} test.py'.format(python_bin),
     'test.py': script,


### PR DESCRIPTION
## Why?

In order to respawn terminated process without exporting upstart, for unexpected error in running programs. Ctrl-c still works with this change.

## Usage

```bash
honcho start --respawn
```