### PR TITLE
Allows `python -m honcho` to act the same as `honcho` (#199).

### DIFF
--- a/honcho/__main__.py
+++ b/honcho/__main__.py
@@ -1,0 +1,4 @@
+from honcho.command import main
+
+if __name__ == '__main__':
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,13 @@
 import os
 import shutil
+import sys
 import tempfile
 from subprocess import Popen, PIPE
 
 import pytest
+
+RUN_AS_PYTHON_PACKAGE = 'package'
+RUN_AS_PYTHON_ENTRYPOINT = 'entrypoint'
 
 
 class TestEnv(object):
@@ -28,11 +32,18 @@ class TestEnv(object):
     def path(self, *args):
         return os.path.join(self.root, *args)
 
-    def run_honcho(self, args):
+    def run_honcho(self, args, runner=RUN_AS_PYTHON_ENTRYPOINT):
+        if runner == RUN_AS_PYTHON_ENTRYPOINT:
+            return self._run_honcho(args, cmd=['honcho'])
+        elif runner == RUN_AS_PYTHON_PACKAGE:
+            return self._run_honcho(args, cmd=[sys.executable, '-m', 'honcho'])
+
+        raise NotImplementedError('Cannot run honcho as %r.' % (runner, ))
+
+    def _run_honcho(self, args, cmd):
         cwd = os.getcwd()
         os.chdir(self.root)
 
-        cmd = ['honcho']
         cmd.extend(args)
 
         # The below is mostly copy-pasted from subprocess.py's check_output (to

--- a/tests/integration/test_check.py
+++ b/tests/integration/test_check.py
@@ -2,7 +2,10 @@ import textwrap
 
 import pytest
 
+all_honcho_runners = pytest.mark.parametrize('runner', ['entrypoint', 'package'])
 
+
+@all_honcho_runners
 @pytest.mark.parametrize('testenv', [{
     'Procfile': textwrap.dedent("""
         foo: python web.py
@@ -10,8 +13,8 @@ import pytest
         baz: node socket.js
     """)
 }], indirect=True)
-def test_check(testenv):
-    ret, out, err = testenv.run_honcho(['check'])
+def test_check(testenv, runner):
+    ret, out, err = testenv.run_honcho(['check'], runner=runner)
 
     assert ret == 0
     assert 'Valid procfile detected' in err

--- a/tests/integration/test_export.py
+++ b/tests/integration/test_export.py
@@ -2,17 +2,20 @@ import os
 
 import pytest
 
+all_honcho_runners = pytest.mark.parametrize('runner', ['entrypoint', 'package'])
 
+
+@all_honcho_runners
 @pytest.mark.parametrize('testenv', [{
     'Procfile': "web: python web.py"
 }], indirect=True)
-def test_export_supervisord(testenv):
+def test_export_supervisord(testenv, runner):
     ret, out, err = testenv.run_honcho([
         'export',
         'supervisord',
         testenv.path('giraffe'),
         '-a', 'neck',
-    ])
+    ], runner=runner)
 
     expected = testenv.path('giraffe', 'neck.conf')
 
@@ -20,16 +23,17 @@ def test_export_supervisord(testenv):
     assert os.path.exists(expected)
 
 
+@all_honcho_runners
 @pytest.mark.parametrize('testenv', [{
     'Procfile': "web: python web.py"
 }], indirect=True)
-def test_export_upstart(testenv):
+def test_export_upstart(testenv, runner):
     ret, out, err = testenv.run_honcho([
         'export',
         'upstart',
         testenv.path('elephant'),
         '-a', 'trunk',
-    ])
+    ], runner=runner)
 
     assert ret == 0
     for filename in ('trunk.conf',
@@ -39,6 +43,7 @@ def test_export_upstart(testenv):
         assert os.path.exists(expected)
 
 
+@all_honcho_runners
 @pytest.mark.parametrize('testenv', [{
     'Procfile': "web: python web.py",
     '.env': """
@@ -52,13 +57,13 @@ SQ_DOLLAR='costs $UNINTERPOLATED amount'
 DQ_DOLLAR="costs $UNINTERPOLATED amount"
 """
 }], indirect=True)
-def test_export_upstart_environment(testenv):
+def test_export_upstart_environment(testenv, runner):
     ret, out, err = testenv.run_honcho([
         'export',
         'upstart',
         testenv.path('test'),
         '-a', 'envvars',
-    ])
+    ], runner=runner)
 
     assert ret == 0
 

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -13,50 +13,54 @@ script = textwrap.dedent("""
     print("error output", file=sys.stderr)
 """)
 
+all_honcho_runners = pytest.mark.parametrize('runner', ['entrypoint', 'package'])
 
+
+@all_honcho_runners
 @pytest.mark.parametrize('testenv', [{
     'test.py': script
 }], indirect=True)
-def test_run(testenv):
-    ret, out, err = testenv.run_honcho(['run', python_bin, 'test.py'])
+def test_run(testenv, runner):
+    ret, out, err = testenv.run_honcho(['run', python_bin, 'test.py'], runner=runner)
 
     assert ret == 0
     assert out == 'elephant\n'
     assert 'error output\n' in err
 
 
+@all_honcho_runners
 @pytest.mark.parametrize('testenv', [{
     '.env': 'ANIMAL=giraffe',
     'test.py': script,
 }], indirect=True)
-def test_run_env(testenv):
-    ret, out, err = testenv.run_honcho(['run', python_bin, 'test.py'])
+def test_run_env(testenv, runner):
+    ret, out, err = testenv.run_honcho(['run', python_bin, 'test.py'], runner=runner)
 
     assert ret == 0
     assert out == 'giraffe\n'
 
-
+@all_honcho_runners
 @pytest.mark.parametrize('testenv', [{
     '.env.x': 'ANIMAL=giraffe',
     'test.py': script,
 }], indirect=True)
-def test_run_args_before_command(testenv):
+def test_run_args_before_command(testenv, runner):
     # Regression test for #122 -- ensure that common args can be given
     # before the subcommand.
-    ret, out, err = testenv.run_honcho(['-e', '.env.x',
-                                        'run', python_bin, 'test.py'])
+    ret, out, err = testenv.run_honcho(['-e', '.env.x', 'run', python_bin, 'test.py'], runner=runner)
 
     assert ret == 0
     assert out == 'giraffe\n'
 
 
+@all_honcho_runners
 @pytest.mark.parametrize('testenv', [{
     'test.py': script
 }], indirect=True)
-def test_run_options_positionals_separator(testenv):
+def test_run_options_positionals_separator(testenv, runner):
     # Regression test for #159 -- ensure that honcho handles the '--'
     # options/positionals separator correctly.
-    ret, out, err = testenv.run_honcho(['run', '--', python_bin, 'test.py'])
+    ret, out, err = testenv.run_honcho(['run', '--', python_bin, 'test.py'], runner=runner)
 
     assert ret == 0
     assert out == 'elephant\n'

--- a/tests/integration/test_start.py
+++ b/tests/integration/test_start.py
@@ -13,30 +13,35 @@ script = textwrap.dedent("""
     print("error output", file=sys.stderr)
 """)
 
+all_honcho_runners = pytest.mark.parametrize('runner', ['entrypoint', 'package'])
 
+
+@all_honcho_runners
 @pytest.mark.parametrize('testenv', [{
     'Procfile': 'foo: {0} test.py'.format(python_bin),
     'test.py': script,
 }], indirect=True)
-def test_start(testenv):
-    ret, out, err = testenv.run_honcho(['start'])
+def test_start(testenv, runner):
+    ret, out, err = testenv.run_honcho(['start'], runner=runner)
 
     assert ret == 0
     assert 'elephant' in out
     assert 'error output' in out
 
 
+@all_honcho_runners
 @pytest.mark.parametrize('testenv', [{
     '.env': 'ANIMAL=giraffe',
     'Procfile': 'foo: {0} test.py'.format(python_bin),
     'test.py': script,
 }], indirect=True)
-def test_start_env(testenv):
-    ret, out, err = testenv.run_honcho(['start'])
+def test_start_env(testenv, runner):
+    ret, out, err = testenv.run_honcho(['start'], runner=runner)
 
     assert 'giraffe' in out
 
 
+@all_honcho_runners
 @pytest.mark.parametrize('testenv', [{
     '.env': 'PROCFILE=Procfile.dev',
     'Procfile': 'foo: {0} test.py'.format(python_bin),
@@ -47,12 +52,13 @@ def test_start_env(testenv):
         print("mongoose")
         """)
 }], indirect=True)
-def test_start_env_procfile(testenv):
-    ret, out, err = testenv.run_honcho(['start'])
+def test_start_env_procfile(testenv, runner):
+    ret, out, err = testenv.run_honcho(['start'], runner=runner)
 
     assert 'mongoose' in out
 
 
+@all_honcho_runners
 @pytest.mark.parametrize('testenv', [{
     'Procfile': 'foo: {0} test.py'.format(python_bin),
     'Procfile.dev': 'bar: {0} test_dev.py'.format(python_bin),
@@ -62,14 +68,15 @@ def test_start_env_procfile(testenv):
         print("mongoose")
         """)
 }], indirect=True)
-def test_start_procfile_after_command(testenv):
+def test_start_procfile_after_command(testenv, runner):
     # Regression test for #173: Ensure that -f argument can be provided after
     # command
-    ret, out, err = testenv.run_honcho(['start', '-f', 'Procfile.dev'])
+    ret, out, err = testenv.run_honcho(['start', '-f', 'Procfile.dev'], runner=runner)
 
     assert 'mongoose' in out
 
 
+@all_honcho_runners
 @pytest.mark.parametrize('testenv', [{
     'Procfile': 'foo: {0} test.py'.format(python_bin),
     'Procfile.dev': 'bar: {0} test_dev.py'.format(python_bin),
@@ -79,18 +86,19 @@ def test_start_procfile_after_command(testenv):
         print("mongoose")
         """)
 }], indirect=True)
-def test_start_procfile_before_command(testenv):
+def test_start_procfile_before_command(testenv, runner):
     # Test case for #173: Ensure that -f argument can be provided before command
-    ret, out, err = testenv.run_honcho(['-f', 'Procfile.dev', 'start'])
+    ret, out, err = testenv.run_honcho(['-f', 'Procfile.dev', 'start'], runner=runner)
 
     assert 'mongoose' in out
 
 
+@all_honcho_runners
 @pytest.mark.parametrize('testenv', [{
     'Procfile': 'foo: {0} test.py'.format(python_bin),
     'test.py': 'import sys; sys.exit(42)',
 }], indirect=True)
-def test_start_returncode(testenv):
-    ret, out, err = testenv.run_honcho(['start'])
+def test_start_returncode(testenv, runner):
+    ret, out, err = testenv.run_honcho(['start'], runner=runner)
 
     assert ret == 42


### PR DESCRIPTION
Few points here:

* I was a bit reluctant to add that much testing for a 3 line patches, especially because all integration tests
  are now ran twice, thus doubling their execution time. But I still think this needs to be tested, so I'm open
  to ideas for shortening the tests implementation.
* Maybe there is a way to have a "parametrized-fixture" thing in pytest?
* Should I add something in documentation?