### PR TITLE
Allow process kwargs to get passed into manager

### DIFF
--- a/honcho/manager.py
+++ b/honcho/manager.py
@@ -47,9 +47,10 @@ class Manager(object):
     #: this will contain a return code that can be used with `sys.exit`.
     returncode = None
 
-    def __init__(self, printer=None):
+    def __init__(self, printer=None, process_kwargs=None):
         self.events = multiprocessing.Queue()
         self.returncode = None
+        self._process_kwargs = process_kwargs
 
         self._colours = get_colours()
         self._env = Env()
@@ -176,7 +177,8 @@ class Manager(object):
         for name, p in self._processes.items():
             p['process'] = multiprocessing.Process(name=name,
                                                    target=p['obj'].run,
-                                                   args=(self.events, True))
+                                                   args=(self.events, True,
+                                                         self._process_kwargs))
             p['process'].start()
 
     def _all_started(self):

--- a/honcho/process.py
+++ b/honcho/process.py
@@ -36,9 +36,16 @@ class Process(object):
         self._child = None
         self._child_ctor = Popen
 
-    def run(self, events=None, ignore_signals=False):
+    def run(self, events=None, ignore_signals=False, process_kwargs=None):
         self._events = events
-        self._child = self._child_ctor(self.cmd, env=self.env, cwd=self.cwd)
+        process_kwargs = process_kwargs or {}
+        kwargs = dict(
+            dict(
+                env=self.env,
+                cwd=self.cwd,
+            ),
+            **process_kwargs)
+        self._child = self._child_ctor(self.cmd, **kwargs)
         self._send_message({'pid': self._child.pid}, type='start')
 
         # Don't pay attention to SIGINT/SIGTERM. The process itself is

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -70,8 +70,9 @@ class FakeProcess(object):
         self._events = None
         self._options = {}
 
-    def run(self, events=None, ignore_signals=False):
-        self._report('run', events_passed=events is not None)
+    def run(self, events=None, ignore_signals=False, process_kwargs=None):
+        self._report('run', events_passed=events is not None,
+                     process_kwargs=process_kwargs)
 
     def _report(self, type, **data):
         if self._events is not None:
@@ -243,6 +244,15 @@ class TestManager(object):
         assert len(evts) == 1
         assert evts[0]['name'] == 'foo'
         assert evts[0]['events_passed']
+
+    def test_loop_calls_with_process_kwargs(self):
+        kwargs = {'cwd': '../'}
+        self.m = Manager(printer=self.p, process_kwargs=kwargs)
+        self.m._env = FakeEnv()
+        self.run_history('one')
+        evts = self.h.find_events(type='run')
+        assert len(evts) == 1
+        assert evts[0]['process_kwargs'] == kwargs
 
     def test_printer_receives_messages_in_correct_order(self):
         self.run_history('one')


### PR DESCRIPTION
When using `Manager` directly it could be convenient to pass `kwargs` to `Popen`. For example, you could set `shell` to `False` to avoid using the shell. In general this PR should allow for greater flexibility when using `Manager` directly while having no impact on the more standard CLI usage of `honcho`.