### PR TITLE
Allow `-` (dash) in process type

### DIFF
--- a/doc/using_procfiles.rst
+++ b/doc/using_procfiles.rst
@@ -18,10 +18,10 @@ source tree that contains zero or more lines of the form::
 
     <process type>: <command>
 
-The ``process type`` is a string which may contain alphanumerics and underscores
-(``[A-Za-z0-9_]+``), and uniquely identifies one type of process which can be
-run to form your application. For example: ``web``, ``worker``, or
-``my_process_123``.
+The ``process type`` is a string which may contain alphanumerics as well as
+underscores and dashes (``[A-Za-z0-9_-]+``), and uniquely identifies one type
+of process which can be run to form your application. For example: ``web``,
+``worker``, or ``my_process_123``.
 
 ``command`` is a shell commandline which will be executed to spawn a process of
 the specified type.

--- a/honcho/environ.py
+++ b/honcho/environ.py
@@ -13,7 +13,7 @@ if compat.ON_WINDOWS:
     import ctypes
 
 
-PROCFILE_LINE = re.compile(r'^([A-Za-z0-9_]+):\s*(.+)$')
+PROCFILE_LINE = re.compile(r'^([A-Za-z0-9_-]+):\s*(.+)$')
 
 
 class Env(object):

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -155,9 +155,16 @@ def test_environ_parse(content, commands):
     [
         # Invalid characters
         """
-        -foo: command
+        +foo: command
         """,
         {}
+    ],
+    [
+        # Valid -/_ characters
+        """
+        -foo_bar: command
+        """,
+        {'-foo_bar': 'command'}
     ],
     [
         # Shell metacharacters


### PR DESCRIPTION
This change adds `-` (dash) to the list of valid characters for a process type. I propose this change because it seems to be the de facto Procfile standard.

I recently made a [VS Code extension with syntax highlighting for Procfiles](https://marketplace.visualstudio.com/items?itemName=benspaulding.procfile). In my testing I found that Honcho is the only Foreman clone that does not allow dashes in the process type. Allowing it would bring it in line with Foreman and the others.

Here is an excerpt from the project README that details my findings:

---

## Foreman & Clones

The most used and robust are:

- [Foreman][] (Ruby)
- [Honcho][] (Python)
- [Goreman][] (Go)

Others include:

- [node-foreman][Noreman] (Node) *— n.b. How on earth is this not named “Noreman”? I insist on referring to it as such!*
- [Shoreman][] (Shell)
- [forego][] (Go)

[Foreman]: http://ddollar.github.io/foreman/
[Honcho]: https://github.com/nickstenning/honcho
[Goreman]: https://github.com/mattn/goreman
[Noreman]: https://github.com/strongloop/node-foreman
[Shoreman]: https://github.com/chrismytton/shoreman
[forego]: https://github.com/ddollar/forego

*[…]*

| *`Procfile`* |  Foreman  |  Honcho   |  Goreman  |  Noreman  |  Shoreman  |  forego  |
| ------------ |:---------:|:---------:|:---------:|:---------:|:----------:|:--------:|
| `n0 …      ` |     #     |     #     |     #     |        ✗  |         ✗  |       ✗  |
| `n1: …     ` |  ✓        |  ✓        |  ✓        |  ✓        |  ✓         |  ✓       |
| ` n2: …    ` |     #     |     #     |  ✓        |        ✗  |  ✓         |       ✗  |
| `n3 : …    ` |     #     |     #     |  ✓        |        ✗  |  ✓         |       ✗  |
| `n4:…      ` |  ✓        |  ✓        |  ✓        |  ✓        |         ✗  |  ✓       |
| `n 5: …    ` |     #     |     #     |  ✓        |        ✗  |  ✓   /  ✗  |       ✗  |
| `# n6: …   ` |     #     |     #     |     #     |     #     |     #      |       ✗  |
| `#n7: …    ` |     #     |     #     |     #     |     #     |     #      |       ✗  |
| `n-8: …    ` |  ✓        |     #     |  ✓        |  ✓        |  ✓         |  ✓       |
| `n9 :…     ` |     #     |     #     |  ✓        |        ✗  |  ✓         |       ✗  |

|     *legend*      |     |
| ----------------- |:---:|
| valid process     |  ✓  |
| comment / ignored |  #  |
| error / hang      |  ✗  |

---

Closes #206.