### PR TITLE
Add a CLI option to disable the timestamp in the prefix

### DIFF
--- a/honcho/command.py
+++ b/honcho/command.py
@@ -46,6 +46,9 @@ def _add_common_args(parser, with_defaults=False):
     parser.add_argument('--no-prefix',
                         action='store_true',
                         help='disable logging prefix')
+    parser.add_argument('--no-prefix-time',
+                        action='store_true',
+                        help='disable time in logging prefix')
     parser.add_argument('-f', '--procfile',
                         metavar='FILE',
                         default=suppress,
@@ -221,7 +224,8 @@ def command_start(args):
 
     manager = Manager(Printer(sys.stdout,
                               colour=(not args.no_colour),
-                              prefix=(not args.no_prefix)))
+                              prefix=(not args.no_prefix),
+                              prefix_time=(not args.no_prefix_time)))
 
     for p in environ.expand_processes(processes,
                                       concurrency=concurrency,

--- a/honcho/printer.py
+++ b/honcho/printer.py
@@ -18,12 +18,14 @@ class Printer(object):
                  time_format="%H:%M:%S",
                  width=0,
                  colour=True,
-                 prefix=True):
+                 prefix=True,
+                 prefix_time=True):
         self.output = output
         self.time_format = time_format
         self.width = width
         self.colour = colour
         self.prefix = prefix
+        self.prefix_time = prefix_time
 
         try:
             # We only want to print coloured messages if the given output supports
@@ -54,8 +56,11 @@ class Printer(object):
         for line in string.splitlines():
             prefix = ''
             if self.prefix:
-                time_formatted = message.time.strftime(self.time_format)
-                prefix = '{time} {name}| '.format(time=time_formatted, name=name)
+                if self.prefix_time:
+                    time_formatted = message.time.strftime(self.time_format)
+                    prefix = '{time} {name}| '.format(time=time_formatted, name=name)
+                else:
+                    prefix = '{name}| '.format(name=name)
                 if self.colour and self._colours_supported and message.colour:
                     prefix = _colour_string(message.colour, prefix)
             print(prefix + line, file=self.output, flush=True)


### PR DESCRIPTION
Hey, this project recently helped me out, thanks for publishing it.  I'm running the same application on two different systems, and it's a bit easier to compare the logs if there's no timestamp on the messages. It's a pretty simple change but, let me know if you have any feedback.