### PR TITLE
add default value  for arg --no-colour, --no-prefix

### DIFF
--- a/honcho/command.py
+++ b/honcho/command.py
@@ -42,9 +42,11 @@ def _add_common_args(parser, with_defaults=False):
                         help='procfile directory (default: .)')
     parser.add_argument('--no-colour',
                         action='store_true',
+                        default=(suppress or False),
                         help='disable coloured output')
     parser.add_argument('--no-prefix',
                         action='store_true',
+                        default=(suppress or False),
                         help='disable logging prefix')
     parser.add_argument('-f', '--procfile',
                         metavar='FILE',


### PR DESCRIPTION
without default value for arg --no-prefix,   you can not use:
    honcho --no-prefix start 
the --no-prefix dost not work, becase overide by sub command arg

you can only use:
    honcho start --no-prefix

so, to add default value to support:
   honcho --no-prefix --no-colour start



