### PR TITLE
docs: fix simple typo, shat -> that

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -272,7 +272,7 @@ epub_copyright = u'2014, Nick Stenning'
 # The format is a list of tuples containing the path and title.
 #epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 #epub_post_files = []
 


### PR DESCRIPTION
There is a small typo in doc/conf.py.

Should read `that` rather than `shat`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md