### PR TITLE
Update interpreter example for tox

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -105,9 +105,9 @@ Tips
 
 If you'd like to run a specific tox environment just use ``-e`` flag e.g.::
 
-    tox -e py27
+    tox -e py39
 
-This will run tests using python2.7 interpreter.
+This will run tests using python3.9 interpreter.
 
 To list all available tox environments run::
 


### PR DESCRIPTION
Python2 is not supported anymore by honcho (and is EOL).
So using a python3 supported release is a better example.