### PR TITLE
Handle deprecation of pkg_resources and favor importlib

### DIFF
--- a/honcho/command.py
+++ b/honcho/command.py
@@ -8,7 +8,6 @@ import signal
 from collections import ChainMap
 from collections import OrderedDict
 from collections import defaultdict
-from pkg_resources import iter_entry_points
 
 from honcho import __version__
 from honcho.environ import Env
@@ -33,9 +32,16 @@ ENV_ARGS = {
     'procfile': 'PROCFILE',
 }
 
-export_choices = dict((_export.name, _export)
-                      for _export in iter_entry_points('honcho_exporters'))
+try:
+    from pkg_resources import iter_entry_points # Python 3.7-3.9
 
+    export_choices = dict((_export.name, _export)
+                          for _export in iter_entry_points('honcho_exporters'))
+except ImportError:
+    from importlib.metadata import entry_points # Python 3.10+
+
+    export_choices = dict((_export.name, _export)
+                          for _export in entry_points(group='honcho_exporters'))
 
 class CommandError(Exception):
     pass


### PR DESCRIPTION
Specifically, the Python 3.10 images on CircleCI no longer include `pkg_resrouces` as it's deprecated:

```
$ honcho start
Traceback (most recent call last):
  File "/home/circleci/myproject/.venv/bin/honcho", line 5, in <module>
    from honcho.command import main
  File "/home/circleci/myproject/.venv/lib/python3.10/site-packages/honcho/command.py", line 10, in <module>
    from pkg_resources import iter_entry_points
ModuleNotFoundError: No module named 'pkg_resources'
```

Starting in Python 3.8, [importlib.metdata](https://docs.python.org/3/library/importlib.metadata.html#entry-points) is the preferred way to find entry points.