### PR TITLE
Fix dead link to Foreman

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -74,7 +74,7 @@ it's made up of multiple independent components. Honcho (and `Foreman`_, and
 
 .. _Procfile: https://devcenter.heroku.com/articles/procfile
 .. _Procfile-based applications: Procfile_
-.. _Foreman: http://ddollar.github.com/foreman
+.. _Foreman: https://ddollar.github.io/foreman/
 .. _Heroku: https://heroku.com/
 .. _gunicorn: http://gunicorn.org/
 .. _runpy: https://docs.python.org/3/library/runpy.html


### PR DESCRIPTION
Fixes this:

<img width="606" alt="image" src="https://user-images.githubusercontent.com/23004737/197575264-0caa033b-017a-4c5c-98a9-cf54e5bc2516.png">
