### PR TITLE
environ: Support variable names containing dots

### DIFF
--- a/honcho/environ.py
+++ b/honcho/environ.py
@@ -60,21 +60,17 @@ def parse(content):
     """
     values = {}
     for line in content.splitlines():
-        lexer = shlex.shlex(line, posix=True)
-        tokens = list(lexer)
-
-        # parses the assignment statement
-        if len(tokens) < 3:
+        try:
+            name, value = line.split('=', 1)
+        except ValueError:
             continue
 
-        name, op = tokens[:2]
-        value = ''.join(tokens[2:])
-
-        if op != '=':
-            continue
-        if not re.match(r'[A-Za-z_][A-Za-z_0-9]*', name):
+        name = name.strip()
+        if not re.match(r'[A-Za-z_][A-Za-z_0-9.]*', name):
             continue
 
+        lexer = shlex.shlex(value, posix=True)
+        value = ''.join(lexer)
         value = value.replace(r'\n', '\n')
         value = value.replace(r'\t', '\t')
         values[name] = value

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -116,6 +116,13 @@ from honcho import environ
          'NEWLINES': 'foo\nbar',
          'DOLLAR': 'foo\\$bar'}
     ],
+    [
+        # "." in value
+        r"""
+        MYVAR.SUB=value
+        """,
+        {'MYVAR.SUB': 'value'}
+    ]
 ])
 def test_environ_parse(content, commands):
     content = textwrap.dedent(content)


### PR DESCRIPTION
This is useful for transporting arbitrary settings to applications. It is difficult to implement because shell variable names apparently may not contain dots, but _environment_ variables may. Solving this by parsing the variable name with `shlex` and re-joining the tokens would swallow white space and thus turn "FOO BAR=baz" into a valid assignment. So use everything up to the assignment operator verbatim as the variable name and only shlex the value.

Environment variables containing dots are handled fine by e.g. the `env` command and the `subprocess` module.