### PR TITLE
Intercept the InterruptedError on Windows, and don't use shell.

### DIFF
--- a/honcho/manager.py
+++ b/honcho/manager.py
@@ -111,6 +111,8 @@ class Manager(object):
             except queue.Empty:
                 if exit:
                     break
+            except InterruptedError:
+                exit = True
             else:
                 if msg.type == 'line':
                     self._printer.write(msg)

--- a/honcho/process.py
+++ b/honcho/process.py
@@ -67,7 +67,7 @@ class Popen(subprocess.Popen):
         options = {
             'stdout': subprocess.PIPE,
             'stderr': subprocess.STDOUT,
-            'shell': True,
+            'shell': not ON_WINDOWS,
             'close_fds': not ON_WINDOWS,
         }
         options.update(**kwargs)


### PR DESCRIPTION
If you don't intercept the `InterruptedError` it looks like this:
```
Traceback (most recent call last):
  File "C:\Users\exampleminiconda3\envs\clip\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\exampleminiconda3\envs\clip\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\exampleminiconda3\envs\clip\Scripts\honcho.exe\__main__.py", line 7, in <module>
  File "C:\Users\exampleminiconda3\envs\clip\lib\site-packages\honcho\command.py", line 291, in main
    COMMANDS[args.command](args)
  File "C:\Users\exampleminiconda3\envs\clip\lib\site-packages\honcho\command.py", line 237, in command_start
    manager.loop()
  File "C:\Users\exampleminiconda3\envs\clip\lib\site-packages\honcho\manager.py", line 109, in loop
    msg = self.events.get(timeout=0.1)
  File "C:\Users\exampleminiconda3\envs\clip\lib\multiprocessing\queues.py", line 113, in get
    if not self._poll(timeout):
  File "C:\Users\exampleminiconda3\envs\clip\lib\multiprocessing\connection.py", line 257, in poll
    return self._poll(timeout)
  File "C:\Users\exampleminiconda3\envs\clip\lib\multiprocessing\connection.py", line 330, in _poll
    return bool(wait([self], timeout))
  File "C:\Users\exampleminiconda3\envs\clip\lib\multiprocessing\connection.py", line 879, in wait
    ready_handles = _exhaustive_wait(waithandle_to_obj.keys(), timeout)
  File "C:\Users\exampleminiconda3\envs\clip\lib\multiprocessing\connection.py", line 811, in _exhaustive_wait
    res = _winapi.WaitForMultipleObjects(L, False, timeout)
InterruptedError: [Errno 4] Interrupted function call
```
It also does not successfully terminate the subprocesses because when it uses `'shell': True` in `Popen`, it spawns a command console which does not appear to successfully pass on the termination message. Since this never ends the subprocesses, the parent process doesn't end, and everything hangs.

If (when the `^C` fails to stop it) you kill the parent `honcho` process using Task Manager, it ends, but it doesn't kill the subprocesses in that case.

This is all on Windows 11. It is demonstratable with a simple `Procfile` that looks like:
```
simple_test: python hold_on.py
```
and a Python script that looks like:
```python
import time

time.sleep(30)
print("Hold on")
time.sleep(10)
print("Done")
```
Doing `honcho start` from the Windows 11 command shell, and then hitting `^C` doesn't kill the subprocess (despite giving an ugly stack dump) nor does it exit `honcho` until the sleeps have completed on their own.  With this patch, it gives a clean message that it's terminating, and it successfully terminates immediately.