### PR TITLE
Fixes on systemd exporter

### DIFF
--- a/honcho/export/systemd.py
+++ b/honcho/export/systemd.py
@@ -36,6 +36,7 @@ class Export(BaseExport):
         for process_master_name, proc_groups in process_groups:
             process_master_wants = [".".join([p[0], "service"]) for p in proc_groups]
             context['process_master_wants'] = " ".join(process_master_wants)
+            context['process_master_name'] = process_master_name
             yield File("{0}.target".format(process_master_name), process_master_tpl.render(context))
 
             for process_name, process in proc_groups:

--- a/honcho/export/templates/systemd/process.service
+++ b/honcho/export/templates/systemd/process.service
@@ -14,3 +14,6 @@ StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=%n
 KillMode=process
+
+[Install]
+WantedBy=multi-user.target

--- a/honcho/export/templates/systemd/process.service
+++ b/honcho/export/templates/systemd/process.service
@@ -1,5 +1,5 @@
 [Unit]
-PartOf={{ app }}-{{ process.name }}.target
+PartOf={{ app }}-{{ process_master_name }}.target
 
 [Service]
 User={{ user }}

--- a/honcho/export/templates/systemd/process.service
+++ b/honcho/export/templates/systemd/process.service
@@ -10,7 +10,7 @@ Environment={{ k }}={{ v | shellquote }}
 ExecStart={{ shell }} -lc '{{ process.cmd }}'
 Restart=always
 StandardInput=null
-StandardOutput=syslog
-StandardError=syslog
+StandardOutput=journal
+StandardError=journal
 SyslogIdentifier=%n
 KillMode=process

--- a/honcho/export/templates/systemd/process.service
+++ b/honcho/export/templates/systemd/process.service
@@ -1,5 +1,5 @@
 [Unit]
-PartOf={{ app }}-{{ process_master_name }}.target
+PartOf={{ process_master_name }}.target
 
 [Service]
 User={{ user }}

--- a/honcho/export/templates/systemd/process_master.target
+++ b/honcho/export/templates/systemd/process_master.target
@@ -1,3 +1,3 @@
 [Unit]
 PartOf={{ app }}.target
-
+Wants={{ process_master_wants }}


### PR DESCRIPTION
Hey there :wave: 

Thanks for creating honcho, I've been having fun with it both locally as using it in our deploy strategy.

Took the liberty to apply some fixes to the systemd exporter.
- Move to `journal`
- Add `multi-user.target`
- Fix the target dependency tree

This should fix most of #230. I've kept the `KillMode` on `process` though. For our use-case, defaulting to the `control-group` worked best. We're removing the killmode on deploy from the files.